### PR TITLE
Ensure workspace dir is used and not current dir

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,7 @@ runs:
         # Check if running inside of the action repo
         if [[ -z "${{ github.action_ref }}" ]]; then if [[ "${{ github.ref_name }}" =~ (.*)/merge ]]; then tag=pr-${BASH_REMATCH[1]}; else tag=${{ github.ref_name }}; fi; fi
         if [[ -z "${tag}" ]]; then tag=${{ github.action_ref }}; fi
-        docker run --privileged --volume .:/github/workspace/ ghcr.io/jasonn3/build-container-installer:${tag} \
+        docker run --privileged --volume ${{ github.workspace }}:/github/workspace/ ghcr.io/jasonn3/build-container-installer:${tag} \
           ARCH=${{ inputs.arch }} \
           IMAGE_NAME=${{ inputs.image_name }} \
           IMAGE_REPO=${{ inputs.image_repo }} \


### PR DESCRIPTION
If the previous steps had changed directory, this could result in the wrong directory being passed to the container