### PR TITLE
Fix Container Copying to Directory

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -86,6 +86,7 @@ jobs:
 
       - name: Build ISO with new container
         uses: ./
+        id: build
         with:
           arch: ${{ env.ARCH}}
           image_name: ${{ env.IMAGE_NAME}}
@@ -101,7 +102,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.ISO_NAME }}.iso
-          path: ${{ github.workspace}}/*
+          path: | 
+            ${{ steps.build.outputs.iso-path }}
+            ${{ steps.build.outputs.checksum-path }}
           if-no-files-found: error
           retention-days: 0
           compression-level: 0

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -105,10 +105,10 @@ jobs:
         id: upload
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.IMAGE_NAME }}-${{ env.IMAGE_TAG }}-${{ matrix.version }}.iso
+          name: ${{ steps.build.outputs.iso_name }}
           path: |
-            ${{ steps.build.outputs.iso_name }}
-            ${{ steps.build.outputs.iso_name }}-CHECKSUM
+            ${{ steps.build.outputs.iso_path }}
+            ${{ steps.build.outputs.iso_path }}-CHECKSUM
           if-no-files-found: error
           retention-days: 0
           compression-level: 0

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Build ISO with new container
         env:
-          ISO_NAME: ${{ env.IMAGE_NAME }}-${{ env.IMAGE_VERSION }}
+          ISO_NAME: ${{ env.IMAGE_NAME }}-${{ env.VERSION }}
         uses: ./
         with:
           arch: ${{ env.ARCH}}
@@ -98,7 +98,7 @@ jobs:
 
       - name: Upload ISO as artifact
         env:
-          ISO_NAME: ${{ env.IMAGE_NAME }}-${{ env.IMAGE_VERSION }}
+          ISO_NAME: ${{ env.IMAGE_NAME }}-${{ env.VERSION }}
         id: upload
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -105,7 +105,7 @@ jobs:
         id: upload
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.build.outputs.iso_name }}
+          name: ${{ env.IMAGE_NAME }}-${{ env.IMAGE_TAG }}-${{ matrix.version }}.iso
           path: |
             ${{ steps.build.outputs.iso_name }}
             ${{ steps.build.outputs.iso_name }}-CHECKSUM

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,6 +17,7 @@ env:
   VARIANT: 'Server'
   SECURE_BOOT_KEY_URL: 'https://github.com/ublue-os/akmods/raw/main/certs/public_key.der'
   ENROLLMENT_PASSWORD: 'container-installer'
+  ISO_NAME: ${{ env.IMAGE_NAME }}-${{ env.IMAGE_VERSION }}
 
 
 jobs:
@@ -92,13 +93,14 @@ jobs:
           variant: ${{ env.VARIANT }}
           secure_boot_key_url: ${{ env.SECURE_BOOT_KEY_URL }}
           enrollment_password: ${{ env.ENROLLMENT_PASSWORD }}
+          iso_name: ${{ env.ISO_NAME }}
 
       - name: Upload ISO as artifact
         id: upload
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.IMAGE_NAME }}-${{ env.VERSION }}.iso
-          path: ${{ github.workspace}}/${{ env.IMAGE_NAME }}-${{ env.VERSION }}.iso
+          name: ${{ env.ISO_NAME }}.iso
+          path: ${{ github.workspace}}/${{ env.ISO_NAME }}.iso
           if-no-files-found: error
           retention-days: 0
           compression-level: 0

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -98,7 +98,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.IMAGE_NAME }}-${{ env.VERSION }}.iso
-          path: ${{ github.workspace}}/{{ env.IMAGE_NAME }}-${{ env.VERSION }}.iso
+          path: ${{ github.workspace}}/${{ env.IMAGE_NAME }}-${{ env.VERSION }}.iso
           if-no-files-found: error
           retention-days: 0
           compression-level: 0

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,7 +17,6 @@ env:
   VARIANT: 'Server'
   SECURE_BOOT_KEY_URL: 'https://github.com/ublue-os/akmods/raw/main/certs/public_key.der'
   ENROLLMENT_PASSWORD: 'container-installer'
-  OUTPUT_DIR: '/build-container-installer/build'
 
 
 jobs:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           containerfiles: Containerfile
           tags: ${{ steps.meta.outputs.tags }}
-          
+
       - name: Push image
         uses: redhat-actions/push-to-registry@v2
         with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -67,11 +67,9 @@ jobs:
         version:
           - 38
           - 39
+    outputs:
+      iso_name: ${{ steps.build.outputs.iso_name }}
     steps:
-      - name: Set Environment Variables
-        run: |
-          echo "ISO_NAME=${{ env.IMAGE_NAME }}-${{ matrix.VERSION }}" >> $GITHUB_ENV
-
       - name: Checkout repo
         uses: actions/checkout@v4
 
@@ -101,14 +99,16 @@ jobs:
           variant: ${{ env.VARIANT }}
           secure_boot_key_url: ${{ env.SECURE_BOOT_KEY_URL }}
           enrollment_password: ${{ env.ENROLLMENT_PASSWORD }}
-          iso_name: ${{ env.ISO_NAME }}
+          iso_name: ${{ env.IMAGE_NAME }}-${{ env.IMAGE_TAG }}-${{ matrix.version }}.iso
 
       - name: Upload ISO as artifact
         id: upload
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.ISO_NAME }}.iso
-          path: ${{ steps.build.outputs.output-directory }}
+          name: ${{ steps.build.outputs.iso_name }}
+          path: |
+            ${{ steps.build.outputs.iso_name }}
+            ${{ steps.build.outputs.iso_name }}-CHECKSUM
           if-no-files-found: error
           retention-days: 0
           compression-level: 0
@@ -127,17 +127,13 @@ jobs:
           - 38
           - 39
     steps:
-      - name: Set Environment Variables
-        run: |
-          echo "ISO_NAME=${{ env.IMAGE_NAME }}-${{ matrix.VERSION }}" >> $GITHUB_ENV
-
       - name: Checkout repo
         uses: actions/checkout@v4
 
       - name: Ensure qemu is installed
         run: |
           sudo apt-get update
-          sudo apt-get install -y qemu qemu-utils xorriso unzip qemu-system-x86 netcat socat jq isomd5sum ansible make
+          sudo apt-get install -y qemu qemu-utils xorriso unzip qemu-system-x86 netcat socat jq isomd5sum ansible make coreutils
 
       - name: Create disk
         run: |
@@ -146,14 +142,16 @@ jobs:
       - name: Download generated ISO
         uses: actions/download-artifact@v4
         with:
-          name: ${{ env.ISO_NAME }}.iso
+          name: ${{ needs.build-and-push-iso.outputs.iso_name }}
     
       - name: Verify ISO
-        run: checkisomd5 ${{ env.ISO_NAME }}.iso
+        run: |
+          checkisomd5 ${{ needs.build-and-push-iso.outputs.iso_name }}
+          sha256sum -c ${{ needs.build-and-push-iso.outputs.iso_name }}-CHECKSUM
 
       - name: Run ISO checks
         run: |
-          mv ${{ env.ISO_NAME }}.iso deploy.iso
+          mv ${{ needs.build-and-push-iso.outputs.iso_name }} deploy.iso
           make test-iso VERSION=${{ matrix.version }}
 
       - name: Add Kickstart and Grub options to ISO

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,6 +17,7 @@ env:
   VARIANT: 'Server'
   SECURE_BOOT_KEY_URL: 'https://github.com/ublue-os/akmods/raw/main/certs/public_key.der'
   ENROLLMENT_PASSWORD: 'container-installer'
+  OUTPUT_DIR: '/github/workspace/build'
 
 
 jobs:
@@ -95,14 +96,14 @@ jobs:
 
       - name: Rename ISO
         run: |
-          mv build/deploy.iso build/${{ env.IMAGE_NAME }}-${{ env.VERSION }}.iso
+          mv ${{ env.OUTPUT_DIR }}/deploy.iso ${{ env.OUTPUT_DIR }}/${{ env.IMAGE_NAME }}-${{ env.VERSION }}.iso
 
       - name: Upload ISO as artifact
         id: upload
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.IMAGE_NAME }}-${{ env.VERSION }}.iso
-          path: build/*.iso
+          path: ${{ env.OUTPUT_DIR }}/*.iso
           if-no-files-found: error
           retention-days: 0
           compression-level: 0

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -68,7 +68,8 @@ jobs:
           - 38
           - 39
     outputs:
-      iso_name: ${{ steps.build.outputs.iso_name }}
+      iso_name-38: ${{ steps.save_output.outputs.iso_name-38 }}
+      iso_name-39: ${{ steps.save_output.outputs.iso_name-39 }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -100,6 +101,12 @@ jobs:
           secure_boot_key_url: ${{ env.SECURE_BOOT_KEY_URL }}
           enrollment_password: ${{ env.ENROLLMENT_PASSWORD }}
           iso_name: ${{ env.IMAGE_NAME }}-${{ env.IMAGE_TAG }}-${{ matrix.version }}.iso
+
+      - name: Save output
+        id: save_output
+        shell: bash
+        run: |
+          echo "iso_name-${{ matrix.version }}=${{ steps.build.outputs.iso_name}}" >> $GITHUB_OUTPUT
 
       - name: Upload ISO as artifact
         id: upload
@@ -142,16 +149,16 @@ jobs:
       - name: Download generated ISO
         uses: actions/download-artifact@v4
         with:
-          name: ${{ needs.build-and-push-iso.outputs.iso_name }}
+          name: ${{ needs['build-and-push-iso']['outputs'][format('iso_name-{0}', matrix.version)] }}
     
       - name: Verify ISO
         run: |
-          checkisomd5 ${{ needs.build-and-push-iso.outputs.iso_name }}
-          sha256sum -c ${{ needs.build-and-push-iso.outputs.iso_name }}-CHECKSUM
+          checkisomd5 ${{ needs['build-and-push-iso']['outputs'][format('iso_name-{0}', matrix.version)] }}
+          sha256sum -c ${{ needs['build-and-push-iso']['outputs'][format('iso_name-{0}', matrix.version)] }}-CHECKSUM
 
       - name: Run ISO checks
         run: |
-          mv ${{ needs.build-and-push-iso.outputs.iso_name }} deploy.iso
+          mv ${{ needs['build-and-push-iso']['outputs'][format('iso_name-{0}', matrix.version)] }} deploy.iso
           make test-iso VERSION=${{ matrix.version }}
 
       - name: Add Kickstart and Grub options to ISO

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -57,14 +57,16 @@ jobs:
 
   build-and-push-iso:
     runs-on: ubuntu-latest
-    env:
-      ISO_NAME: ${{ env.IMAGE_NAME }}-${{ env.VERSION }}
     needs:
       - build-container
     permissions:
       contents: read
       packages: write
     steps:
+      - name: Set Environment Variables
+        run: |
+          echo "ISO_NAME=${{ env.IMAGE_NAME }}-${{ env.VERSION }}" >> $GITHUB_ENV
+
       - name: Checkout repo
         uses: actions/checkout@v4
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -97,6 +97,8 @@ jobs:
           iso_name: ${{ env.ISO_NAME }}
 
       - name: Upload ISO as artifact
+        env:
+          ISO_NAME: ${{ env.IMAGE_NAME }}-${{ env.IMAGE_VERSION }}
         id: upload
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -64,6 +64,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+    env:
+      ISO_NAME: ${{ env.IMAGE_NAME }}-${{ env.VERSION }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -83,8 +85,6 @@ jobs:
             type=ref,event=pr
 
       - name: Build ISO with new container
-        env:
-          ISO_NAME: ${{ env.IMAGE_NAME }}-${{ env.VERSION }}
         uses: ./
         with:
           arch: ${{ env.ARCH}}
@@ -97,8 +97,6 @@ jobs:
           iso_name: ${{ env.ISO_NAME }}
 
       - name: Upload ISO as artifact
-        env:
-          ISO_NAME: ${{ env.IMAGE_NAME }}-${{ env.VERSION }}
         id: upload
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -108,9 +108,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.ISO_NAME }}.iso
-          path: | 
-            ${{ steps.build.outputs.iso-path }}
-            ${{ steps.build.outputs.checksum-path }}
+          path: ${{ steps.build.outputs.output-directory }}
           if-no-files-found: error
           retention-days: 0
           compression-level: 0
@@ -226,4 +224,3 @@ jobs:
               ./${check}
             fi
           done
-

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -59,13 +59,13 @@ jobs:
 
   build-and-push-iso:
     runs-on: ubuntu-latest
+    env:
+      ISO_NAME: ${{ env.IMAGE_NAME }}-${{ env.VERSION }}
     needs:
       - build-container
     permissions:
       contents: read
       packages: write
-    env:
-      ISO_NAME: ${{ env.IMAGE_NAME }}-${{ env.VERSION }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,7 +18,6 @@ env:
   SECURE_BOOT_KEY_URL: 'https://github.com/ublue-os/akmods/raw/main/certs/public_key.der'
   ENROLLMENT_PASSWORD: 'container-installer'
 
-
 jobs:
   build-container:
     runs-on: ubuntu-latest
@@ -55,7 +54,6 @@ jobs:
           tags: ${{ steps.build-image.outputs.tags }}
           username: ${{ github.actor }}
           password: ${{ github.token }}
-
 
   build-and-push-iso:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,7 +17,7 @@ env:
   VARIANT: 'Server'
   SECURE_BOOT_KEY_URL: 'https://github.com/ublue-os/akmods/raw/main/certs/public_key.der'
   ENROLLMENT_PASSWORD: 'container-installer'
-  OUTPUT_DIR: '/github/workspace/build'
+  OUTPUT_DIR: '/build-container-installer/build'
 
 
 jobs:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -127,6 +127,10 @@ jobs:
           - 38
           - 39
     steps:
+      - name: Set Environment Variables
+        run: |
+          echo "ISO_NAME=${{ env.IMAGE_NAME }}-${{ matrix.VERSION }}" >> $GITHUB_ENV
+
       - name: Checkout repo
         uses: actions/checkout@v4
 
@@ -142,14 +146,14 @@ jobs:
       - name: Download generated ISO
         uses: actions/download-artifact@v4
         with:
-          name: ${{ env.IMAGE_NAME }}-${{ env.IMAGE_TAG }}-${{ matrix.version }}.iso
+          name: ${{ env.ISO_NAME }}.iso
     
       - name: Verify ISO
-        run: checkisomd5 ${{ env.IMAGE_NAME }}-${{ env.IMAGE_TAG }}-${{ matrix.version }}.iso
+        run: checkisomd5 ${{ env.ISO_NAME }}.iso
 
       - name: Run ISO checks
         run: |
-          mv ${{ env.IMAGE_NAME }}-${{ env.IMAGE_TAG }}-${{ matrix.version }}.iso deploy.iso
+          mv ${{ env.ISO_NAME }}.iso deploy.iso
           make test-iso VERSION=${{ matrix.version }}
 
       - name: Add Kickstart and Grub options to ISO

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -101,7 +101,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.ISO_NAME }}.iso
-          path: ${{ github.workspace}}/${{ env.ISO_NAME }}.iso
+          path: ${{ github.workspace}}/*
           if-no-files-found: error
           retention-days: 0
           compression-level: 0

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,7 +17,6 @@ env:
   VARIANT: 'Server'
   SECURE_BOOT_KEY_URL: 'https://github.com/ublue-os/akmods/raw/main/certs/public_key.der'
   ENROLLMENT_PASSWORD: 'container-installer'
-  ISO_NAME: ${{ env.IMAGE_NAME }}-${{ env.IMAGE_VERSION }}
 
 
 jobs:
@@ -84,6 +83,8 @@ jobs:
             type=ref,event=pr
 
       - name: Build ISO with new container
+        env:
+          ISO_NAME: ${{ env.IMAGE_NAME }}-${{ env.IMAGE_VERSION }}
         uses: ./
         with:
           arch: ${{ env.ARCH}}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -94,16 +94,12 @@ jobs:
           secure_boot_key_url: ${{ env.SECURE_BOOT_KEY_URL }}
           enrollment_password: ${{ env.ENROLLMENT_PASSWORD }}
 
-      - name: Rename ISO
-        run: |
-          mv ${{ env.OUTPUT_DIR }}/deploy.iso ${{ env.OUTPUT_DIR }}/${{ env.IMAGE_NAME }}-${{ env.VERSION }}.iso
-
       - name: Upload ISO as artifact
         id: upload
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.IMAGE_NAME }}-${{ env.VERSION }}.iso
-          path: ${{ env.OUTPUT_DIR }}/*.iso
+          path: ${{ github.workspace}}/{{ env.IMAGE_NAME }}-${{ env.VERSION }}.iso
           if-no-files-found: error
           retention-days: 0
           compression-level: 0

--- a/Containerfile
+++ b/Containerfile
@@ -9,6 +9,7 @@ ENV IMAGE_TAG="${VERSION}"
 ENV VARIANT="Server"
 ENV VERSION="${VERSION}"
 ENV WEB_UI="false"
+ENV ISO_NAME="${IMAGE_NAME}-${IMAGE_TAG}"
 
 RUN mkdir /build-container-installer
 

--- a/Containerfile
+++ b/Containerfile
@@ -19,7 +19,7 @@ WORKDIR /build-container-installer
 
 RUN dnf install -y make && make install-deps
 
-VOLUME /build-container-installer/build
+VOLUME ${OUTPUT_DIR}
 
 ENTRYPOINT ["/bin/bash", "/build-container-installer/entrypoint.sh"]
 

--- a/Containerfile
+++ b/Containerfile
@@ -9,7 +9,6 @@ ENV IMAGE_TAG="${VERSION}"
 ENV VARIANT="Server"
 ENV VERSION="${VERSION}"
 ENV WEB_UI="false"
-ENV ISO_NAME="${IMAGE_NAME}-${IMAGE_TAG}"
 
 RUN mkdir /build-container-installer
 

--- a/Containerfile
+++ b/Containerfile
@@ -9,7 +9,6 @@ ENV IMAGE_TAG="${VERSION}"
 ENV VARIANT="Server"
 ENV VERSION="${VERSION}"
 ENV WEB_UI="false"
-ENV OUTPUT_DIR="/build-container-installer/build"
 
 RUN mkdir /build-container-installer
 
@@ -19,7 +18,7 @@ WORKDIR /build-container-installer
 
 RUN dnf install -y make && make install-deps
 
-VOLUME ${OUTPUT_DIR}
+VOLUME /build-container-installer/build
 
 ENTRYPOINT ["/bin/bash", "/build-container-installer/entrypoint.sh"]
 

--- a/Containerfile
+++ b/Containerfile
@@ -9,7 +9,7 @@ ENV IMAGE_TAG="${VERSION}"
 ENV VARIANT="Server"
 ENV VERSION="${VERSION}"
 ENV WEB_UI="false"
-ENV OUTPUT_DIR="/github/workspace/build"
+ENV OUTPUT_DIR="/build-container-installer/build"
 
 RUN mkdir /build-container-installer
 

--- a/Containerfile
+++ b/Containerfile
@@ -9,8 +9,10 @@ ENV IMAGE_TAG="${VERSION}"
 ENV VARIANT="Server"
 ENV VERSION="${VERSION}"
 ENV WEB_UI="false"
+ENV OUTPUT_DIR="/github/workspace/build"
 
 RUN mkdir /build-container-installer
+
 COPY / /build-container-installer/
 
 WORKDIR /build-container-installer

--- a/Makefile
+++ b/Makefile
@@ -41,10 +41,7 @@ build/deploy.iso:  boot.iso container/$(IMAGE_NAME)-$(IMAGE_TAG) xorriso/input.t
 	xorriso -dialog on < $(_BASE_DIR)/xorriso/input.txt
 	implantisomd5 build/deploy.iso
 	mv build/deploy.iso build/$(ISO_NAME).iso
-	ls build/
-	pushd build/
-	sha256sum $(ISO_NAME).iso > $(ISO_NAME)-CHECKSUM
-	popd
+	cd build && sha256sum $(ISO_NAME).iso > $(ISO_NAME)-CHECKSUM
 
 # Step 1: Generate Lorax Templates
 lorax_templates/post_%.tmpl: lorax_templates/scripts/post/%

--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,9 @@ build/deploy.iso:  boot.iso container/$(IMAGE_NAME)-$(IMAGE_TAG) xorriso/input.t
 	xorriso -dialog on < $(_BASE_DIR)/xorriso/input.txt
 	implantisomd5 build/deploy.iso
 	mv build/deploy.iso build/$(ISO_NAME).iso
-	cd build
+	pushd $(_BASE_DIR)/build
 	sha256sum $(ISO_NAME).iso > $(ISO_NAME)-CHECKSUM
+	popd
 
 # Step 1: Generate Lorax Templates
 lorax_templates/post_%.tmpl: lorax_templates/scripts/post/%

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ ENROLLMENT_PASSWORD =
 SECURE_BOOT_KEY_URL =
 ADDITIONAL_TEMPLATES = 
 ROOTFS_SIZE = 4
+ISO_NAME = $(IMAGE_NAME)-$(IMAGE_TAG)
 
 # Generated vars
 ## Formatting = _UPPERCASE
@@ -39,6 +40,7 @@ build/deploy.iso:  boot.iso container/$(IMAGE_NAME)-$(IMAGE_TAG) xorriso/input.t
 	mkdir $(_BASE_DIR)/build || true
 	xorriso -dialog on < $(_BASE_DIR)/xorriso/input.txt
 	implantisomd5 build/deploy.iso
+	mv build/deploy.iso build/$(ISO_NAME).iso
 
 # Step 1: Generate Lorax Templates
 lorax_templates/post_%.tmpl: lorax_templates/scripts/post/%

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,6 @@ SECURE_BOOT_KEY_URL =
 ADDITIONAL_TEMPLATES =
 EXTRA_BOOT_PARAMS =
 ROOTFS_SIZE = 4
-ISO_NAME = $(IMAGE_NAME)-$(IMAGE_TAG)
 
 # Generated vars
 ## Formatting = _UPPERCASE
@@ -41,8 +40,6 @@ build/deploy.iso:  boot.iso container/$(IMAGE_NAME)-$(IMAGE_TAG) xorriso/input.t
 	mkdir $(_BASE_DIR)/build || true
 	xorriso -dialog on < $(_BASE_DIR)/xorriso/input.txt
 	implantisomd5 build/deploy.iso
-	mv build/deploy.iso build/$(ISO_NAME).iso
-	cd build && sha256sum $(ISO_NAME).iso > $(ISO_NAME)-CHECKSUM
 
 # Step 1: Generate Lorax Templates
 lorax_templates/post_%.tmpl: lorax_templates/scripts/post/%

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,8 @@ build/deploy.iso:  boot.iso container/$(IMAGE_NAME)-$(IMAGE_TAG) xorriso/input.t
 	xorriso -dialog on < $(_BASE_DIR)/xorriso/input.txt
 	implantisomd5 build/deploy.iso
 	mv build/deploy.iso build/$(ISO_NAME).iso
+	cd build
+	sha256sum $(ISO_NAME).iso > $(ISO_NAME)-CHECKSUM
 
 # Step 1: Generate Lorax Templates
 lorax_templates/post_%.tmpl: lorax_templates/scripts/post/%
@@ -176,7 +178,7 @@ clean:
 	rm -f $(_BASE_DIR)/*.log || true
 
 install-deps:
-	dnf install -y lorax xorriso skopeo
+	dnf install -y lorax xorriso skopeo coreutils
 
 test-iso:
 	$(eval _TESTS = $(filter-out README.md,$(shell ls tests/iso)))

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,8 @@ build/deploy.iso:  boot.iso container/$(IMAGE_NAME)-$(IMAGE_TAG) xorriso/input.t
 	xorriso -dialog on < $(_BASE_DIR)/xorriso/input.txt
 	implantisomd5 build/deploy.iso
 	mv build/deploy.iso build/$(ISO_NAME).iso
-	pushd $(_BASE_DIR)/build
+	ls build/
+	pushd build/
 	sha256sum $(ISO_NAME).iso > $(ISO_NAME)-CHECKSUM
 	popd
 

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ ifeq ($(WEB_UI),true)
 _LORAX_ARGS += -i anaconda-webui
 endif
 
-# Step 7: Buid end ISO
+# Step 7: Build end ISO
 ## Default action
 build/deploy.iso:  boot.iso container/$(IMAGE_NAME)-$(IMAGE_TAG) xorriso/input.txt
 	mkdir $(_BASE_DIR)/build || true

--- a/README.md
+++ b/README.md
@@ -48,13 +48,15 @@ The following variables can be used to customize the created ISO.
 | image_repo           | Repository containing the source container image                             | quay.io/fedora-ostree-desktops |
 | image_tag            | Tag of the source container image                                            | *VERSION*                      |
 | iso_name             | Name of the ISO you wish to output when completed                            | build/deploy.iso               |
-| secure_boot_key_url  | Secure boot key that is installed from URL location                          | \[empty\]                      |
+| secure_boot_key_url  | Secure boot key that is installed from URL location\*\*                      | \[empty\]                      |
 | variant              | Source container variant\*                                                   | Server                         |
 | version              | Fedora version of installer to build                                         | 39                             |
 | web_ui               | Enable Anaconda WebUI (experimental)                                         | false                          |
 
 \*Available options for VARIANT can be found by running `dnf provides system-release`.
 Variant will be the third item in the package name. Example: `fedora-release-kinoite-39-34.noarch` will be kinoite
+
+\*\* If you need to reference a local file, you can use `file://*path*`
 
 ### Outputs
 | Variable | Description                             | Usage                                            |
@@ -70,7 +72,7 @@ The Makefile contains all of the commands that are run in the action. There are 
 
 `make install-deps` can be used to install the necessary packages
 
-See [Customizing](#customizing) for information about customizing the ISO that gets created.
+See [Customizing](#customizing) for information about customizing the ISO that gets created. All variable should be specified CAPITALIZED.
 
 ### Container
 A container with `make install-deps` already run is provided at `ghcr.io/jasonn3/build-container-installer:latest`
@@ -79,17 +81,17 @@ To use the container file, run `docker run --privileged --volume .:/build-contai
 
 This will create an ISO with the baked in defaults of the container image. The resulting file will be called `deploy.iso`
 
-See [Customizing](#customizing) for information about customizing the ISO that gets created. The variable can either be defined as environment variables.
+See [Customizing](#customizing) for information about customizing the ISO that gets created. The variable can either be defined as environment variables. All variable should be specified CAPITALIZED.
 Examples:
 
 Building an ISO to install Fedora 38
 ```bash
-docker run --rm --privileged --volume .:/build-container-installer/build  ghcr.io/jasonn3/build-container-installer:latest VERSION=38 IMAGE_NAME=base IMAGE_TAG=38 VARIANT=Server
+docker run --rm --privileged --volume .:/github/workspace/build  ghcr.io/jasonn3/build-container-installer:latest VERSION=38 IMAGE_NAME=base IMAGE_TAG=38 VARIANT=Server
 ```
 
 Building an ISO to install Fedora 39
 ```bash
-docker run --rm --privileged --volume .:/build-container-installer/build  ghcr.io/jasonn3/build-container-installer:latest VERSION=39 IMAGE_NAME=base IMAGE_TAG=39 VARIANT=Server
+docker run --rm --privileged --volume .:/github/workspace/build  ghcr.io/jasonn3/build-container-installer:latest VERSION=39 IMAGE_NAME=base IMAGE_TAG=39 VARIANT=Server
 ```
 
 ### VSCode Dev Container

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ This action is designed to be called from a GitHub workflow using the following 
   id: upload
   uses: actions/upload-artifact@v4
   with:
-    name: ${{ env.IMAGE_NAME }}-${{ env.IMAGE_TAG }}-${{ env.VERSION }}.iso
+    name: ${{ steps.build.outputs.iso_name }}
     path: |
-      ${{ steps.build.outputs.iso_name }}
-      ${{ steps.build.outputs.iso_name }}-CHECKSUM
+      ${{ steps.build.outputs.iso_path }}
+      ${{ steps.build.outputs.iso_path }}-CHECKSUM
   if-no-files-found: error
   retention-days: 0
   compression-level: 0
@@ -57,9 +57,10 @@ The following variables can be used to customize the created ISO.
 Variant will be the third item in the package name. Example: `fedora-release-kinoite-39-34.noarch` will be kinoite
 
 ### Outputs
-| Variable          | Description                                            | Usage                                                    |
-| ----------------- | ------------------------------------------------------ | -------------------------------------------------------- |
-| iso_name          | Path to just the ISO file that the action creates      | ${{ steps.YOUR_ID_FOR_ACTION.outputs.iso_name }}         |
+| Variable | Description                             | Usage                                            |
+| -------- | ----------------------------------------| ------------------------------------------------ |
+| iso_name | The name of the resulting .iso          | ${{ steps.YOUR_ID_FOR_ACTION.outputs.iso_name }} |
+| iso_path | The name and path of the resulting .iso | ${{ steps.YOUR_ID_FOR_ACTION.outputs.iso_name }} |
 
 For outputs, see example above.
 

--- a/README.md
+++ b/README.md
@@ -34,27 +34,28 @@ See [Customizing](#customizing) for information about customizing the ISO that g
 The following variables can be used to customize the created ISO.
 
 ### Inputs
-| Variable          | Description                                              | Default Value                  |
-| ----------------- | -------------------------------------------------------- | ------------------------------ |
-| ARCH              | Architecture for image to build                          | x86_64                         |
-| VERSION           | Fedora version of installer to build                     | 39                             |
-| IMAGE_REPO        | Repository containing the source container image         | quay.io/fedora-ostree-desktops |
-| IMAGE_NAME        | Name of the source container image                       | base                           |
-| IMAGE_TAG         | Tag of the source container image                        | *VERSION*                      |
-| EXTRA_BOOT_PARAMS | Extra params used by grub to boot the anaconda installer | \[empty\]                      |
-| VARIANT           | Source container variant\*                               | Server                         |
-| WEB_UI            | Enable Anaconda WebUI (experimental)                     | false                          |
-| ISO_NAME          | Name of the ISO you wish to output when completed        | IMAGE_NAME-IMAGE_TAG           |
+| Variable             | Description                                                                  | Default Value                  |
+| -------------------- | ---------------------------------------------------------------------------- | ------------------------------ |
+| additional_templates | Space delimited list of additional Lorax templates to include                | \[empty\]                      |
+| arch                 | Architecture for image to build                                              | x86_64                         |
+| enrollment_password  | Used for supporting secure boot (requires SECURE_BOOT_KEY_URL to be defined) | container-installer            |
+| extra_boot_params    | Extra params used by grub to boot the anaconda installer                     | \[empty\]                      |
+| image_name           | Name of the source container image                                           | base                           |
+| image_repo           | Repository containing the source container image                             | quay.io/fedora-ostree-desktops |
+| image_tag            | Tag of the source container image                                            | *VERSION*                      |
+| iso_name             | Name of the ISO you wish to output when completed                            | build/deploy.iso               |
+| secure_boot_key_url  | Secure boot key that is installed from URL location                          | \[empty\]                      |
+| variant              | Source container variant\*                                                   | Server                         |
+| version              | Fedora version of installer to build                                         | 39                             |
+| web_ui               | Enable Anaconda WebUI (experimental)                                         | false                          |
 
-Available options for VARIANT can be found by running `dnf provides system-release`. 
+\*Available options for VARIANT can be found by running `dnf provides system-release`.
 Variant will be the third item in the package name. Example: `fedora-release-kinoite-39-34.noarch` will be kinoite
 
 ### Outputs
 | Variable          | Description                                            | Usage                                                    |
 | ----------------- | ------------------------------------------------------ | -------------------------------------------------------- |
-| output-directory  | Path to all files in the output directory              | ${{ steps.YOUR_ID_FOR_ACTION.outputs.output-directory }} |
-| iso-path          | Path to just the ISO file that the action creates      | ${{ steps.YOUR_ID_FOR_ACTION.outputs.iso-path }}         |
-| checksum-path     | Path to just the checksum file that the action creates | ${{ steps.YOUR_ID_FOR_ACTION.outputs.checksum-path }}    |
+| iso_name          | Path to just the ISO file that the action creates      | ${{ steps.YOUR_ID_FOR_ACTION.outputs.iso_name }}         |
 
 For outputs, see example above.
 

--- a/README.md
+++ b/README.md
@@ -8,12 +8,26 @@ This action is designed to be called from a GitHub workflow using the following 
 ```yaml
 - name: Build ISO
   uses: jasonn3/build-container-installer/v1.0.0
+  id: build
   with:
     arch: ${{ env.ARCH}}
     image_name: ${{ env.IMAGE_NAME}}
     image_repo: ${{ env.IMAGE_REPO}}
     version: ${{ env.VERSION }}
     variant: ${{ env.VARIANT }}
+
+# This example is for uploading your ISO as a Github artifact. You can do something similar using any cloud storage, so long as you copy the output
+- name: Upload ISO as artifact
+  id: upload
+  uses: actions/upload-artifact@v4
+  with:
+    name: my_iso.iso
+    path: |
+      ${{ steps.build.outputs.iso_path }}
+      ${{ steps.build.outputs.checksum-path }}
+  if-no-files-found: error
+  retention-days: 0
+  compression-level: 0
 ```
 
 See [Customizing](#customizing) for information about customizing the ISO that gets created using `with`
@@ -21,6 +35,7 @@ See [Customizing](#customizing) for information about customizing the ISO that g
 ## Customizing
 The following variables can be used to customize the created ISO.
 
+### Inputs
 | Variable          | Description                                              | Default Value                  |
 | ----------------- | -------------------------------------------------------- | ------------------------------ |
 | ARCH              | Architecture for image to build                          | x86_64                         |
@@ -35,6 +50,14 @@ The following variables can be used to customize the created ISO.
 
 Available options for VARIANT can be found by running `dnf provides system-release`. 
 Variant will be the third item in the package name. Example: `fedora-release-kinoite-39-34.noarch` will be kinoite
+
+### Outputs
+| Variable          | Description                                              | Usage                                            |
+| ----------------- | -------------------------------------------------------- | ------------------------------------------------ |
+| iso-path          | Path to ISO file that the action creates                 | ${{ steps.YOUR_ID_FOR_ACTION.outputs.iso_path }} |
+| checksum-path     | Path to the checksum file that the action creates        | ${{ steps.YOUR_ID_FOR_ACTION.outputs.iso_path }} |
+
+For outputs, see example above.
 
 ## Development
 ### Makefile

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ A container with `make install-deps` already run is provided at `ghcr.io/jasonn3
 
 To use the container file, run `docker run --privileged --volume .:/build-container-installer/build ghcr.io/jasonn3/build-container-installer:latest`.
 
-This will create an ISO with the baked in defaults of the container image.
+This will create an ISO with the baked in defaults of the container image. The resulting file will be called `deploy.iso`
 
 See [Customizing](#customizing) for information about customizing the ISO that gets created. The variable can either be defined as environment variables.
 Examples:

--- a/README.md
+++ b/README.md
@@ -22,9 +22,7 @@ This action is designed to be called from a GitHub workflow using the following 
   uses: actions/upload-artifact@v4
   with:
     name: my_iso.iso
-    path: |
-      ${{ steps.build.outputs.iso_path }}
-      ${{ steps.build.outputs.checksum-path }}
+    path: ${{ steps.build.outputs.output-directory }}
   if-no-files-found: error
   retention-days: 0
   compression-level: 0
@@ -52,10 +50,11 @@ Available options for VARIANT can be found by running `dnf provides system-relea
 Variant will be the third item in the package name. Example: `fedora-release-kinoite-39-34.noarch` will be kinoite
 
 ### Outputs
-| Variable          | Description                                              | Usage                                            |
-| ----------------- | -------------------------------------------------------- | ------------------------------------------------ |
-| iso-path          | Path to ISO file that the action creates                 | ${{ steps.YOUR_ID_FOR_ACTION.outputs.iso_path }} |
-| checksum-path     | Path to the checksum file that the action creates        | ${{ steps.YOUR_ID_FOR_ACTION.outputs.iso_path }} |
+| Variable          | Description                                            | Usage                                                    |
+| ----------------- | ------------------------------------------------------ | -------------------------------------------------------- |
+| output-directory  | Path to all files in the output directory              | ${{ steps.YOUR_ID_FOR_ACTION.outputs.output-directory }} |
+| iso-path          | Path to just the ISO file that the action creates      | ${{ steps.YOUR_ID_FOR_ACTION.outputs.iso-path }}         |
+| checksum-path     | Path to just the checksum file that the action creates | ${{ steps.YOUR_ID_FOR_ACTION.outputs.checksum-path }}    |
 
 For outputs, see example above.
 
@@ -129,4 +128,3 @@ Build a new container image:
 	"privileged": true
 }
 ```
-

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The following variables can be used to customize the created ISO.
 | EXTRA_BOOT_PARAMS | Extra params used by grub to boot the anaconda installer | \[empty\]                      |
 | VARIANT           | Source container variant\*                               | Server                         |
 | WEB_UI            | Enable Anaconda WebUI (experimental)                     | false                          |
+| ISO_NAME          | Name of the ISO you wish to output when completed        | IMAGE_NAME-IMAGE_TAG           |
 
 Available options for VARIANT can be found by running `dnf provides system-release`. 
 Variant will be the third item in the package name. Example: `fedora-release-kinoite-39-34.noarch` will be kinoite
@@ -55,12 +56,12 @@ Examples:
 
 Building an ISO to install Fedora 38
 ```bash
-docker run --rm --privileged --volume .:/build-container-installer/build -e VERSION=38 -e IMAGE_NAME=base -e IMAGE_TAG=38 -e VARIANT=Server ghcr.io/jasonn3/build-container-installer:latest
+docker run --rm --privileged --volume .:/build-container-installer/build  ghcr.io/jasonn3/build-container-installer:latest VERSION=38 IMAGE_NAME=base IMAGE_TAG=38 VARIANT=Server
 ```
 
 Building an ISO to install Fedora 39
 ```bash
-docker run --rm --privileged --volume .:/build-container-installer/build -e VERSION=39 -e IMAGE_NAME=base -e IMAGE_TAG=39 -e VARIANT=Server ghcr.io/jasonn3/build-container-installer:latest
+docker run --rm --privileged --volume .:/build-container-installer/build  ghcr.io/jasonn3/build-container-installer:latest VERSION=39 IMAGE_NAME=base IMAGE_TAG=39 VARIANT=Server
 ```
 
 ### VSCode Dev Container

--- a/README.md
+++ b/README.md
@@ -13,16 +13,20 @@ This action is designed to be called from a GitHub workflow using the following 
     arch: ${{ env.ARCH}}
     image_name: ${{ env.IMAGE_NAME}}
     image_repo: ${{ env.IMAGE_REPO}}
+    image_tag: ${{ env.IMAGE_TAG }}
     version: ${{ env.VERSION }}
     variant: ${{ env.VARIANT }}
+    iso_name: ${{ env.IMAGE_NAME }}-${{ env.IMAGE_TAG }}-${{ env.VERSION }}.iso
 
 # This example is for uploading your ISO as a Github artifact. You can do something similar using any cloud storage, so long as you copy the output
 - name: Upload ISO as artifact
   id: upload
   uses: actions/upload-artifact@v4
   with:
-    name: my_iso.iso
-    path: ${{ steps.build.outputs.output-directory }}
+    name: ${{ env.IMAGE_NAME }}-${{ env.IMAGE_TAG }}-${{ env.VERSION }}.iso
+    path: |
+      ${{ steps.build.outputs.iso_name }}
+      ${{ steps.build.outputs.iso_name }}-CHECKSUM
   if-no-files-found: error
   retention-days: 0
   compression-level: 0

--- a/action.yml
+++ b/action.yml
@@ -65,7 +65,7 @@ runs:
         # Check if running inside of the action repo
         if [[ -z "${{ github.action_ref }}" ]]; then if [[ "${{ github.ref_name }}" =~ (.*)/merge ]]; then tag=pr-${BASH_REMATCH[1]}; else tag=${{ github.ref_name }}; fi; fi
         if [[ -z "${tag}" ]]; then tag=${{ github.action_ref }}; fi
-        docker run --privileged --volume /github/workspace:/build-container-installer/build ghcr.io/jasonn3/build-container-installer:${tag} \
+        docker run --privileged --volume ${{ github.workspace }}:/github/workspace ghcr.io/jasonn3/build-container-installer:${tag} \
           ARCH=${{ inputs.arch }} \
           IMAGE_NAME=${{ inputs.image_name }} \
           IMAGE_REPO=${{ inputs.image_repo }} \
@@ -80,8 +80,8 @@ runs:
     - name: Rename ISO file
       shell: bash
       run: |
-        mv /github/workspace/deploy.iso /github/workspace/${{ inputs.iso_name }}.iso
-        cd /github/workspace
+        mv ${{ github.workspace }}/deploy.iso ${{ github.workspace }}/${{ inputs.iso_name }}.iso
+        cd ${{ github.workspace }}
         sha256sum ${{ inputs.iso_name }}.iso > ${{ inputs.iso_name }}-CHECKSUM
         echo "ISO_PATH=$(realpath ${{ github.workspace }}/${{ inputs.iso_name }}.iso)" >> $GITHUB_OUTPUT
         echo "CHECKSUM_PATH=$(realpath ${{ github.workspace }}/${{ inputs.iso_name }}-CHECKSUM)" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ inputs:
     deprecationMessage: No longer used. github.action_ref replaces the need for this. Will be removed in a future version.
     required: false
   additional_templates:
-    description: Space delimetered list of additional Lorax templates to include
+    description: Space delimited list of additional Lorax templates to include
     required: false
 
 outputs:

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,9 @@ inputs:
     required: false
 
 outputs:
+  output-directory:
+    value: ${{ steps.run_docker.outputs.OUTPUT_DIRECTORY }}
+    description: The location of all output objects
   iso-path:
     value: ${{ steps.run_docker.outputs.ISO_PATH }}
     description: The location of the .iso object
@@ -80,8 +83,9 @@ runs:
     - name: Rename ISO file
       shell: bash
       run: |
-        mv ${{ github.workspace }}/deploy.iso ${{ github.workspace }}/${{ inputs.iso_name }}.iso
-        cd ${{ github.workspace }}
+        mv ${{ github.workspace }}/build/deploy.iso ${{ github.workspace }}/build/${{ inputs.iso_name }}.iso
+        cd ${{ github.workspace }}/build
         sha256sum ${{ inputs.iso_name }}.iso > ${{ inputs.iso_name }}-CHECKSUM
-        echo "ISO_PATH=$(realpath ${{ github.workspace }}/${{ inputs.iso_name }}.iso)" >> $GITHUB_OUTPUT
-        echo "CHECKSUM_PATH=$(realpath ${{ github.workspace }}/${{ inputs.iso_name }}-CHECKSUM)" >> $GITHUB_OUTPUT
+        echo "OUTPUT_DIRECTORY=$(realpath ${{ github.workspace }}/build/)" >> $GITHUB_OUTPUT
+        echo "ISO_PATH=$(realpath ${{ github.workspace }}/build/${{ inputs.iso_name }}.iso)" >> $GITHUB_OUTPUT
+        echo "CHECKSUM_PATH=$(realpath ${{ github.workspace }}/build/${{ inputs.iso_name }}-CHECKSUM)" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -39,7 +39,7 @@ inputs:
   output_dir:
     description: Define a specific output directory
     required: false
-    default: "/github/workspace/build"
+    default: "/build-container-installer/build"
   action_version:
     description: Version of the action container to run
     deprecationMessage: No longer used. github.action_ref replaces the need for this. Will be removed in a future version.

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,6 @@ inputs:
   iso_name:
     description: Used for specifying the name of the output iso
     required: false
-    default: "${{ inputs.image_name }}-${{ inputs.image_tag || inputs.version }}"
   enrollment_password:
     description: Used for supporting secure boot (requires SECURE_BOOT_KEY_URL to be defined)
     required: false

--- a/action.yml
+++ b/action.yml
@@ -92,10 +92,10 @@ runs:
         then
           full_path="${iso_name}"
         else
-          fullpath="${{ github.workspace }}/${iso_name}"
+          full_path="${{ github.workspace }}/${iso_name}"
         fi
-        mv ${{ github.workspace }}/build/deploy.iso ${fullpath} || true
-        cd $(dirname ${fullpath})
+        mv ${{ github.workspace }}/build/deploy.iso ${full_path} || true
+        cd $(dirname ${full_path})
         iso_fn=$(basename ${iso_name})
         sha256sum ${iso_fn} > ${iso_fn%.iso}-CHECKSUM
         echo "ISO=${full_path}" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -30,8 +30,9 @@ inputs:
     required: false
     default: "false"
   iso_name:
-    description: Used for specifying the name of the output iso
+    description: Name of the resulting ISO. Relative paths are relative to ${{ github.workspace }}
     required: false
+    default: build/deploy.iso
   enrollment_password:
     description: Used for supporting secure boot (requires SECURE_BOOT_KEY_URL to be defined)
     required: false
@@ -48,15 +49,9 @@ inputs:
     required: false
 
 outputs:
-  output-directory:
-    value: ${{ steps.rename_iso.outputs.OUTPUT_DIRECTORY }}
-    description: The location of all output objects
-  iso-path:
-    value: ${{ steps.rename_iso.outputs.ISO_PATH }}
+  iso_name:
+    value: ${{ steps.rename_iso.outputs.ISO }}
     description: The location of the .iso object
-  checksum-path:
-    value: ${{ steps.rename_iso.outputs.CHECKSUM_PATH }}
-    description: The location of the checksum
 
 runs:
   using: composite
@@ -79,13 +74,25 @@ runs:
           ENROLLMENT_PASSWORD=${{ inputs.enrollment_password }} \
           SECURE_BOOT_KEY_URL=${{ inputs.secure_boot_key_url }} \
           "ADDITIONAL_TEMPLATES=${{ inputs.additional_templates }}"
+
     - name: Rename ISO file
       id: rename_iso
       shell: bash
       run: |
-        mv ${{ github.workspace }}/build/deploy.iso ${{ github.workspace }}/build/${{ inputs.iso_name }}.iso
-        cd ${{ github.workspace }}/build
-        sha256sum ${{ inputs.iso_name }}.iso > ${{ inputs.iso_name }}-CHECKSUM
-        echo "OUTPUT_DIRECTORY=$(realpath ${{ github.workspace }}/build)" >> $GITHUB_OUTPUT
-        echo "ISO_PATH=$(realpath ${{ github.workspace }}/build/${{ inputs.iso_name }}.iso)" >> $GITHUB_OUTPUT
-        echo "CHECKSUM_PATH=$(realpath ${{ github.workspace }}/build/${{ inputs.iso_name }}-CHECKSUM)" >> $GITHUB_OUTPUT
+        if [[ ! ( "${{ inputs.iso_name }}" =~ \.iso$ ) ]]
+        then
+          iso_name="${{ inputs.iso_name }}.iso"
+        else
+          iso_name="${{ inputs.iso_name }}"
+        fi
+        if [[ "${{ inputs.iso_name }}" =~ ^/ ]]
+        then
+          full_path="${iso_name}"
+        else
+          fullpath="${{ github.workspace }}/${iso_name}"
+        fi
+        mv ${{ github.workspace }}/build/deploy.iso ${fullpath} || true
+        cd $(dirname ${fullpath})
+        iso_fn=$(basename ${iso_name})
+        sha256sum ${iso_fn} > ${iso_fn%.iso}-CHECKSUM
+        echo "ISO=${full_path}" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -100,6 +100,6 @@ runs:
         mv ${{ github.workspace }}/build/deploy.iso ${full_path} || true
         cd $(dirname ${full_path})
         iso_fn=$(basename ${iso_name})
-        sha256sum ${iso_fn} > ${iso_fn%.iso}-CHECKSUM
+        sha256sum ${iso_fn} > ${iso_fn}-CHECKSUM
         echo "iso_path=${full_path}" >> $GITHUB_OUTPUT
         echo "iso_name=${iso_fn}" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -53,8 +53,11 @@ inputs:
 
 outputs:
   iso_name:
-    value: ${{ steps.rename_iso.outputs.ISO }}
-    description: The location of the .iso object
+    value: ${{ steps.rename_iso.outputs.iso_name }}
+    description: The name of the resulting .iso
+  iso_path:
+    value: ${{ steps.rename_iso.outputs.iso_path }}
+    description: The name and path of the resulting .iso
 
 runs:
   using: composite
@@ -98,4 +101,5 @@ runs:
         cd $(dirname ${full_path})
         iso_fn=$(basename ${iso_name})
         sha256sum ${iso_fn} > ${iso_fn%.iso}-CHECKSUM
-        echo "ISO=${full_path}" >> $GITHUB_OUTPUT
+        echo "iso_path=${full_path}" >> $GITHUB_OUTPUT
+        echo "iso_name=${iso_fn}" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -2,10 +2,24 @@ name: Build Container Installer
 description: Generates an ISO for installing an OSTree stored in a container image
 
 inputs:
+  action_version:
+    description: Version of the action container to run
+    deprecationMessage: No longer used. github.action_ref replaces the need for this. Will be removed in a future version.
+    required: false
+  additional_templates:
+    description: Space delimited list of additional Lorax templates to include
+    required: false
   arch:
     description: Architecture for image to build
     required: true
     default: x86_64
+  enrollment_password:
+    description: Used for supporting secure boot (requires SECURE_BOOT_KEY_URL to be defined)
+    required: false
+    default: "container-installer"
+  extra_boot_params:
+    description: Extra params used by grub to boot the anaconda installer
+    required: false
   image_name:
     description: Name of the source container image
     required: true
@@ -14,6 +28,16 @@ inputs:
     description: Repository containing the source container image
     required: true
     default: quay.io/fedora-ostree-desktops
+  image_tag:
+    description: Tag of the source container image. Defaults to the installer version
+    required: false
+  iso_name:
+    description: "Name of the resulting ISO. Relative paths are relative to github.workspace"
+    required: false
+    default: build/deploy.iso
+  secure_boot_key_url:
+    description: Secure boot key that is installed from URL location
+    required: false
   variant:
     description: "Source container variant. Available options can be found by running `dnf provides system-release`. Variant will be the third item in the package name. Example: `fedora-release-kinoite-39-34.noarch` will be kinonite"
     required: true
@@ -22,31 +46,10 @@ inputs:
     description: Fedora version of installer to build
     required: true
     default: "39"
-  image_tag:
-    description: Tag of the source container image. Defaults to the installer version
-    required: false
   web_ui:
     description: Enable Anaconda WebUI
     required: false
     default: "false"
-  iso_name:
-    description: "Name of the resulting ISO. Relative paths are relative to github.workspace"
-    required: false
-    default: build/deploy.iso
-  enrollment_password:
-    description: Used for supporting secure boot (requires SECURE_BOOT_KEY_URL to be defined)
-    required: false
-    default: "container-installer"
-  secure_boot_key_url:
-    description: Secure boot key that is installed from URL location
-    required: false
-  action_version:
-    description: Version of the action container to run
-    deprecationMessage: No longer used. github.action_ref replaces the need for this. Will be removed in a future version.
-    required: false
-  additional_templates:
-    description: Space delimited list of additional Lorax templates to include
-    required: false
 
 outputs:
   iso_name:

--- a/action.yml
+++ b/action.yml
@@ -36,10 +36,6 @@ inputs:
   secure_boot_key_url:
     description: Secure boot key that is installed from URL location
     required: false
-  output_dir:
-    description: Define a specific output directory
-    required: false
-    default: "/build-container-installer/build"
   action_version:
     description: Version of the action container to run
     deprecationMessage: No longer used. github.action_ref replaces the need for this. Will be removed in a future version.
@@ -57,7 +53,7 @@ runs:
         # Check if running inside of the action repo
         if [[ -z "${{ github.action_ref }}" ]]; then if [[ "${{ github.ref_name }}" =~ (.*)/merge ]]; then tag=pr-${BASH_REMATCH[1]}; else tag=${{ github.ref_name }}; fi; fi
         if [[ -z "${tag}" ]]; then tag=${{ github.action_ref }}; fi
-        docker run --privileged --volume ${{ github.workspace }}:/github/workspace/ ghcr.io/jasonn3/build-container-installer:${tag} \
+        docker run --privileged --volume ${{ github.workspace }}:/build-container-installer/build ghcr.io/jasonn3/build-container-installer:${tag} \
           ARCH=${{ inputs.arch }} \
           IMAGE_NAME=${{ inputs.image_name }} \
           IMAGE_REPO=${{ inputs.image_repo }} \
@@ -67,6 +63,5 @@ runs:
           WEB_UI=${{ inputs.web_ui }} \
           ENROLLMENT_PASSWORD=${{ inputs.enrollment_password }} \
           SECURE_BOOT_KEY_URL=${{ inputs.secure_boot_key_url }} \
-          OUTPUT_DIR=${{ inputs.output_dir }} \
           "ADDITIONAL_TEMPLATES=${{ inputs.additional_templates }}"
 

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,9 @@ inputs:
   secure_boot_key_url:
     description: Secure boot key that is installed from URL location
     required: false
+  output_dir:
+    description: Define a specific output directory
+    required: false
   action_version:
     description: Version of the action container to run
     deprecationMessage: No longer used. github.action_ref replaces the need for this. Will be removed in a future version.
@@ -63,5 +66,6 @@ runs:
           WEB_UI=${{ inputs.web_ui }} \
           ENROLLMENT_PASSWORD=${{ inputs.enrollment_password }} \
           SECURE_BOOT_KEY_URL=${{ inputs.secure_boot_key_url }} \
+          OUTPUT_DIR=${{ inputs.output_dir }}
           "ADDITIONAL_TEMPLATES=${{ inputs.additional_templates }}"
 

--- a/action.yml
+++ b/action.yml
@@ -47,10 +47,19 @@ inputs:
     description: Space delimetered list of additional Lorax templates to include
     required: false
 
+outputs:
+  iso-path:
+    value: ${{ steps.run_docker.outputs.ISO_PATH }}
+    description: The location of the .iso object
+  checksum-path:
+    value: ${{ steps.run_docker.outputs.CHECKSUM_PATH }}
+    description: The location of the checksum
+
 runs:
   using: composite
   steps:
     - name: Run docker image
+      id: run_docker
       shell: bash
       run: |
         # Check if running inside of the action repo
@@ -68,4 +77,6 @@ runs:
           ENROLLMENT_PASSWORD=${{ inputs.enrollment_password }} \
           SECURE_BOOT_KEY_URL=${{ inputs.secure_boot_key_url }} \
           "ADDITIONAL_TEMPLATES=${{ inputs.additional_templates }}"
+        echo "ISO_PATH=$(realpath ${{ github.workspace }}/${{ inputs.iso_name }}.iso)" >> $GITHUB_OUTPUT
+        echo "CHECKSUM_PATH=$(realpath ${{ github.workspace }}/${{ inputs.iso_name }}-CHECKSUM)" >> $GITHUB_OUTPUT
 

--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ inputs:
     required: false
     default: "false"
   iso_name:
-    description: Name of the resulting ISO. Relative paths are relative to ${{ github.workspace }}
+    description: "Name of the resulting ISO. Relative paths are relative to ${{ github.workspace }}"
     required: false
     default: build/deploy.iso
   enrollment_password:

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: Enable Anaconda WebUI
     required: false
     default: "false"
+  iso_name:
+    description: Used for specifying the name of the output iso
+    required: false
+    default: "${{ inputs.image_name }}-${{ inputs.image_tag || inputs.version }}"
   enrollment_password:
     description: Used for supporting secure boot (requires SECURE_BOOT_KEY_URL to be defined)
     required: false
@@ -61,6 +65,7 @@ runs:
           VERSION=${{ inputs.version }} \
           IMAGE_TAG=${{ inputs.image_tag || inputs.version }} \
           WEB_UI=${{ inputs.web_ui }} \
+          ISO_NAME=${{ inputs.iso_name }} \
           ENROLLMENT_PASSWORD=${{ inputs.enrollment_password }} \
           SECURE_BOOT_KEY_URL=${{ inputs.secure_boot_key_url }} \
           "ADDITIONAL_TEMPLATES=${{ inputs.additional_templates }}"

--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ inputs:
     required: false
     default: "false"
   iso_name:
-    description: "Name of the resulting ISO. Relative paths are relative to ${{ github.workspace }}"
+    description: "Name of the resulting ISO. Relative paths are relative to github.workspace"
     required: false
     default: build/deploy.iso
   enrollment_password:

--- a/action.yml
+++ b/action.yml
@@ -66,6 +66,6 @@ runs:
           WEB_UI=${{ inputs.web_ui }} \
           ENROLLMENT_PASSWORD=${{ inputs.enrollment_password }} \
           SECURE_BOOT_KEY_URL=${{ inputs.secure_boot_key_url }} \
-          OUTPUT_DIR=${{ inputs.output_dir }}
+          OUTPUT_DIR=${{ inputs.output_dir }} \
           "ADDITIONAL_TEMPLATES=${{ inputs.additional_templates }}"
 

--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,7 @@ inputs:
   output_dir:
     description: Define a specific output directory
     required: false
+    default: "/github/workspace/build"
   action_version:
     description: Version of the action container to run
     deprecationMessage: No longer used. github.action_ref replaces the need for this. Will be removed in a future version.

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
     required: true
     default: x86_64
   enrollment_password:
-    description: Used for supporting secure boot (requires SECURE_BOOT_KEY_URL to be defined)
+    description: Used for supporting secure boot (requires secure_boot_key_url to be defined)
     required: false
     default: "container-installer"
   extra_boot_params:

--- a/action.yml
+++ b/action.yml
@@ -65,7 +65,7 @@ runs:
         # Check if running inside of the action repo
         if [[ -z "${{ github.action_ref }}" ]]; then if [[ "${{ github.ref_name }}" =~ (.*)/merge ]]; then tag=pr-${BASH_REMATCH[1]}; else tag=${{ github.ref_name }}; fi; fi
         if [[ -z "${tag}" ]]; then tag=${{ github.action_ref }}; fi
-        docker run --privileged --volume ${{ github.workspace }}:/build-container-installer/build ghcr.io/jasonn3/build-container-installer:${tag} \
+        docker run --privileged --volume /github/workspace:/build-container-installer/build ghcr.io/jasonn3/build-container-installer:${tag} \
           ARCH=${{ inputs.arch }} \
           IMAGE_NAME=${{ inputs.image_name }} \
           IMAGE_REPO=${{ inputs.image_repo }} \
@@ -77,6 +77,11 @@ runs:
           ENROLLMENT_PASSWORD=${{ inputs.enrollment_password }} \
           SECURE_BOOT_KEY_URL=${{ inputs.secure_boot_key_url }} \
           "ADDITIONAL_TEMPLATES=${{ inputs.additional_templates }}"
+    - name: Rename ISO file
+      shell: bash
+      run: |
+        mv /github/workspace/deploy.iso /github/workspace/${{ inputs.iso_name }}.iso
+        cd /github/workspace
+        sha256sum ${{ inputs.iso_name }}.iso > ${{ inputs.iso_name }}-CHECKSUM
         echo "ISO_PATH=$(realpath ${{ github.workspace }}/${{ inputs.iso_name }}.iso)" >> $GITHUB_OUTPUT
         echo "CHECKSUM_PATH=$(realpath ${{ github.workspace }}/${{ inputs.iso_name }}-CHECKSUM)" >> $GITHUB_OUTPUT
-

--- a/action.yml
+++ b/action.yml
@@ -49,20 +49,19 @@ inputs:
 
 outputs:
   output-directory:
-    value: ${{ steps.run_docker.outputs.OUTPUT_DIRECTORY }}
+    value: ${{ steps.rename_iso.outputs.OUTPUT_DIRECTORY }}
     description: The location of all output objects
   iso-path:
-    value: ${{ steps.run_docker.outputs.ISO_PATH }}
+    value: ${{ steps.rename_iso.outputs.ISO_PATH }}
     description: The location of the .iso object
   checksum-path:
-    value: ${{ steps.run_docker.outputs.CHECKSUM_PATH }}
+    value: ${{ steps.rename_iso.outputs.CHECKSUM_PATH }}
     description: The location of the checksum
 
 runs:
   using: composite
   steps:
     - name: Run docker image
-      id: run_docker
       shell: bash
       run: |
         # Check if running inside of the action repo
@@ -81,11 +80,12 @@ runs:
           SECURE_BOOT_KEY_URL=${{ inputs.secure_boot_key_url }} \
           "ADDITIONAL_TEMPLATES=${{ inputs.additional_templates }}"
     - name: Rename ISO file
+      id: rename_iso
       shell: bash
       run: |
         mv ${{ github.workspace }}/build/deploy.iso ${{ github.workspace }}/build/${{ inputs.iso_name }}.iso
         cd ${{ github.workspace }}/build
         sha256sum ${{ inputs.iso_name }}.iso > ${{ inputs.iso_name }}-CHECKSUM
-        echo "OUTPUT_DIRECTORY=$(realpath ${{ github.workspace }}/build/)" >> $GITHUB_OUTPUT
+        echo "OUTPUT_DIRECTORY=$(realpath ${{ github.workspace }}/build)" >> $GITHUB_OUTPUT
         echo "ISO_PATH=$(realpath ${{ github.workspace }}/build/${{ inputs.iso_name }}.iso)" >> $GITHUB_OUTPUT
         echo "CHECKSUM_PATH=$(realpath ${{ github.workspace }}/build/${{ inputs.iso_name }}-CHECKSUM)" >> $GITHUB_OUTPUT

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,3 +15,6 @@ make boot.iso $@
 
 # Add container to ISO
 make build/deploy.iso $@
+
+cp build/deploy.iso /github/workspace/build
+chmod -R ugo=rwx /github/workspace/build

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-for entry in $@;
+for entry in $@
 do
 	export $entry
 done
@@ -22,4 +22,4 @@ mkdir ${OUTPUT_DIR} || true
 # Copy resulting iso to github workspace and fix permissions
 cp build/deploy.iso ${OUTPUT_DIR}
 chmod -R ugo=rwX ${OUTPUT_DIR}
-echo "::set-output name=iso::${OUTPUT_DIR/deploy.iso/}"
+echo "::set-output name=iso::${OUTPUT_DIR}/deploy.iso"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,8 @@
 
 set -ex
 
-for entry in $@; do
+for entry in $@
+do
 	export $entry
 done
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,7 @@ set -ex
 
 for entry in $@
 do
-	export $entry
+  export $entry
 done
 
 # Pull container
@@ -19,6 +19,6 @@ make build/deploy.iso $@
 # Make output dir in github workspace
 mkdir /github/workspace/build || true
 
-# Copy resulting iso to githubworkspace and fix permissions
+# Copy resulting iso to github workspace and fix permissions
 cp build/deploy.iso /github/workspace/build
 chmod -R ugo=rwx /github/workspace/build

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,5 +16,9 @@ make boot.iso $@
 # Add container to ISO
 make build/deploy.iso $@
 
+# Make output dir in github workspace
+mkdir /github/workspace/build || true
+
+# Copy resulting iso to githubworkspace and fix permissions
 cp build/deploy.iso /github/workspace/build
 chmod -R ugo=rwx /github/workspace/build

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,10 +14,3 @@ make boot.iso $@
 
 # Add container to ISO
 make build/deploy.iso $@
-
-# Make output dir in github workspace
-mkdir ${OUTPUT_DIR} || true
-
-# Copy resulting iso to github workspace and fix permissions
-cp /build-container-installer/build/deploy.iso ${OUTPUT_DIR}
-chmod -R ugo=rwX ${OUTPUT_DIR}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,7 @@ set -ex
 
 for entry in $@
 do
-	export $entry
+    export $entry
 done
 
 # Pull container

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,9 +2,8 @@
 
 set -ex
 
-for entry in $@
-do
-  export $entry
+for entry in $@; do
+	export $entry
 done
 
 # Pull container
@@ -17,9 +16,8 @@ make boot.iso $@
 make build/deploy.iso $@
 
 # Make output dir in github workspace
-mkdir /github/workspace/build || true
+mkdir ${OUTPUT_DIR} || true
 
 # Copy resulting iso to github workspace and fix permissions
-cp build/deploy.iso /github/workspace/build
-chmod -R ugo=rwX /github/workspace/build
-
+cp build/deploy.iso ${OUTPUT_DIR}
+chmod -R ugo=rwX ${OUTPUT_DIR}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,3 +14,5 @@ make boot.iso $@
 
 # Add container to ISO
 make build/deploy.iso $@
+
+mv build/deploy.iso build/${IMAGE_NAME}-${VERSION}.iso

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,8 @@
 
 set -ex
 
-for entry in $@; do
+for entry in $@;
+do
 	export $entry
 done
 
@@ -21,5 +22,4 @@ mkdir ${OUTPUT_DIR} || true
 # Copy resulting iso to github workspace and fix permissions
 cp build/deploy.iso ${OUTPUT_DIR}
 chmod -R ugo=rwX ${OUTPUT_DIR}
-
 echo "::set-output name=iso::${OUTPUT_DIR/deploy.iso/}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,7 @@ set -ex
 
 for entry in $@
 do
-    export $entry
+  export $entry
 done
 
 # Pull container

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,4 +15,4 @@ make boot.iso $@
 # Add container to ISO
 make build/deploy.iso $@
 
-mv build/deploy.iso build/${IMAGE_NAME}-${VERSION}.iso
+mv build/deploy.iso build/${ISO_NAME}.iso

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,9 +2,8 @@
 
 set -ex
 
-for entry in $@
-do
-  export $entry
+for entry in $@; do
+	export $entry
 done
 
 # Pull container
@@ -20,6 +19,5 @@ make build/deploy.iso $@
 mkdir ${OUTPUT_DIR} || true
 
 # Copy resulting iso to github workspace and fix permissions
-cp build/deploy.iso ${OUTPUT_DIR}
+cp /build-container-installer/build/deploy.iso ${OUTPUT_DIR}
 chmod -R ugo=rwX ${OUTPUT_DIR}
-echo "::set-output name=iso::${OUTPUT_DIR}/deploy.iso"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,3 +21,5 @@ mkdir ${OUTPUT_DIR} || true
 # Copy resulting iso to github workspace and fix permissions
 cp build/deploy.iso ${OUTPUT_DIR}
 chmod -R ugo=rwX ${OUTPUT_DIR}
+
+echo "::set-output name=iso::${OUTPUT_DIR/deploy.iso/}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,5 +14,3 @@ make boot.iso $@
 
 # Add container to ISO
 make build/deploy.iso $@
-
-mv build/deploy.iso build/${ISO_NAME}.iso


### PR DESCRIPTION
# Purpose

This PR simplifies the renaming of the deploy.iso and adds an additional input called `iso_name`. This input can be used for someone to override the default name we give the ISO. In Universal Blue's case, we have a specific naming convention that is defined by a matrix. Having a variable to define will make things easier.

It also includes adding outputs in the action.yml to be more easily consumed by users of the action.

Last addition was adding creation of a checksum for the ISO. Folks can then sign their checksum in a separate command. Or we can include that functionality as a separate PR.

Fixes: #39 
Fixes: #43 