### PR TITLE
Prep for Anaconda 41

### DIFF
--- a/lorax_templates/flatpak_set_repo.tmpl
+++ b/lorax_templates/flatpak_set_repo.tmpl
@@ -1,4 +1,7 @@
-<%page args="flatpak_remote_name, _flatpak_repo_url"/>
-
+<%page args="flatpak_remote_name, _flatpak_repo_url, version"/>
+% if int(version) >= 41:
+append etc/anaconda/conf.d/anaconda.conf "flatpak_remote = ${flatpak_remote_name} ${_flatpak_repo_url}"
+% else
 replace "flatpak_manager\.add_remote\(\".*\", \".*\"\)" "flatpak_manager.add_remote(\"${flatpak_remote_name}\", \"${_flatpak_repo_url}\")" /usr/lib64/python*/site-packages/pyanaconda/modules/payloads/payload/rpm_ostree/flatpak_installation.py
 replace "flatpak_manager\.replace_installed_refs_remote\(\".*\"\)" "flatpak_manager.replace_installed_refs_remote(\"${flatpak_remote_name}\")" /usr/lib64/python*/site-packages/pyanaconda/modules/payloads/payload/rpm_ostree/flatpak_installation.py
+% endif

--- a/lorax_templates/flatpak_set_repo.tmpl
+++ b/lorax_templates/flatpak_set_repo.tmpl
@@ -1,7 +1,7 @@
 <%page args="flatpak_remote_name, _flatpak_repo_url, version"/>
 % if int(version) >= 41:
 append etc/anaconda/conf.d/anaconda.conf "flatpak_remote = ${flatpak_remote_name} ${_flatpak_repo_url}"
-% else
+% else:
 replace "flatpak_manager\.add_remote\(\".*\", \".*\"\)" "flatpak_manager.add_remote(\"${flatpak_remote_name}\", \"${_flatpak_repo_url}\")" /usr/lib64/python*/site-packages/pyanaconda/modules/payloads/payload/rpm_ostree/flatpak_installation.py
 replace "flatpak_manager\.replace_installed_refs_remote\(\".*\"\)" "flatpak_manager.replace_installed_refs_remote(\"${flatpak_remote_name}\")" /usr/lib64/python*/site-packages/pyanaconda/modules/payloads/payload/rpm_ostree/flatpak_installation.py
 % endif


### PR DESCRIPTION
Starting with version 41, Anaconda will add a configuration variable for `flatpak_remote`. This already gets the code in place so it doesn't get forgotten when Fedora 41 comes out.