### PR TITLE
Use the Lorax templates for the OS version

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -30,7 +30,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          fetch-tags: true
+          fetch-depth: 0
+          fetch-tags: 'true'
 
       - name: Docker meta
         id: meta

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          fetch-tags: true
 
       - name: Docker meta
         id: meta

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -49,6 +49,7 @@ jobs:
         with:
           containerfiles: Containerfile
           tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
 
       - name: Push image
         uses: redhat-actions/push-to-registry@v2

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -79,6 +79,7 @@ jobs:
     outputs:
       iso_name-38: ${{ steps.save_output.outputs.iso_name-38 }}
       iso_name-39: ${{ steps.save_output.outputs.iso_name-39 }}
+      iso_name-40: ${{ steps.save_output.outputs.iso_name-40 }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -73,6 +73,7 @@ jobs:
         version:
           - 38
           - 39
+          - 40
     outputs:
       iso_name-38: ${{ steps.save_output.outputs.iso_name-38 }}
       iso_name-39: ${{ steps.save_output.outputs.iso_name-39 }}
@@ -142,6 +143,7 @@ jobs:
         version:
           - 38
           - 39
+          - 40
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = external/fedora-lorax-templates
 	url = https://pagure.io/fedora-lorax-templates.git
 	branch = f39
+[submodule "external/lorax"]
+	path = external/lorax
+	url = https://github.com/weldr/lorax.git

--- a/Containerfile
+++ b/Containerfile
@@ -1,6 +1,6 @@
-FROM fedora:39
+FROM fedora:40
 
-ARG VERSION=39
+ARG VERSION=40
 
 ENV ARCH="x86_64"
 ENV IMAGE_NAME="base"

--- a/Makefile
+++ b/Makefile
@@ -170,6 +170,8 @@ repos/%.repo: /etc/yum.repos.d/%.repo
 boot.iso: lorax_repo $(filter lorax_templates/%,$(_LORAX_TEMPLATES)) $(_REPO_FILES)
 	rm -Rf $(_BASE_DIR)/results || true
 	mv /etc/rpm/macros.image-language-conf $(_TEMP_DIR)/macros.image-language-conf || true
+	cp /etc/os-release $(_TEMP_DIR)/os-release || true
+	sed -i 's/PLATFORM_ID=.*/PLATFORM_ID="$(_PLATFORM_ID)"/' /etc/os-release
 
 	# Download the secure boot key
 	if [ -n "$(SECURE_BOOT_KEY_URL)" ]; \
@@ -190,6 +192,7 @@ boot.iso: lorax_repo $(filter lorax_templates/%,$(_LORAX_TEMPLATES)) $(_REPO_FIL
 		$(_BASE_DIR)/results/
 	mv $(_BASE_DIR)/results/images/boot.iso $(_BASE_DIR)/
 	mv -f $(_TEMP_DIR)/macros.image-language-conf /etc/rpm/macros.image-language-conf || true
+	mv -f $(_TEMP_DIR)/os-release /etc/os-release || true
 
 # Step 4: Download container image
 container/$(IMAGE_NAME)-$(IMAGE_TAG):

--- a/Makefile
+++ b/Makefile
@@ -166,8 +166,6 @@ repos/%.repo: /etc/yum.repos.d/%.repo
 boot.iso: $(filter lorax_templates/%,$(_LORAX_TEMPLATES)) $(_REPO_FILES)
 	rm -Rf $(_BASE_DIR)/results || true
 	mv /etc/rpm/macros.image-language-conf $(_TEMP_DIR)/macros.image-language-conf || true
-	cp /etc/os-release $(_TEMP_DIR)/os-release || true
-	sed -i 's/PLATFORM_ID=.*/PLATFORM_ID="$(_PLATFORM_ID)"/' /etc/os-release
 
 	# Download the secure boot key
 	if [ -n "$(SECURE_BOOT_KEY_URL)" ]; \
@@ -188,7 +186,6 @@ boot.iso: $(filter lorax_templates/%,$(_LORAX_TEMPLATES)) $(_REPO_FILES)
 		$(_BASE_DIR)/results/
 	mv $(_BASE_DIR)/results/images/boot.iso $(_BASE_DIR)/
 	mv -f $(_TEMP_DIR)/macros.image-language-conf /etc/rpm/macros.image-language-conf || true
-	mv -f $(_TEMP_DIR)/os-release /etc/os-release || true
 
 # Step 4: Download container image
 container/$(IMAGE_NAME)-$(IMAGE_TAG):

--- a/Makefile
+++ b/Makefile
@@ -170,8 +170,6 @@ repos/%.repo: /etc/yum.repos.d/%.repo
 boot.iso: lorax_repo $(filter lorax_templates/%,$(_LORAX_TEMPLATES)) $(_REPO_FILES)
 	rm -Rf $(_BASE_DIR)/results || true
 	mv /etc/rpm/macros.image-language-conf $(_TEMP_DIR)/macros.image-language-conf || true
-	cp /etc/os-release $(_TEMP_DIR)/os-release || true
-	sed -i 's/PLATFORM_ID=.*/PLATFORM_ID="$(_PLATFORM_ID)"/' /etc/os-release
 
 	# Download the secure boot key
 	if [ -n "$(SECURE_BOOT_KEY_URL)" ]; \
@@ -192,7 +190,6 @@ boot.iso: lorax_repo $(filter lorax_templates/%,$(_LORAX_TEMPLATES)) $(_REPO_FIL
 		$(_BASE_DIR)/results/
 	mv $(_BASE_DIR)/results/images/boot.iso $(_BASE_DIR)/
 	mv -f $(_TEMP_DIR)/macros.image-language-conf /etc/rpm/macros.image-language-conf || true
-	mv -f $(_TEMP_DIR)/os-release /etc/os-release || true
 
 # Step 4: Download container image
 container/$(IMAGE_NAME)-$(IMAGE_TAG):

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ build/deploy.iso:  boot.iso container/$(IMAGE_NAME)-$(IMAGE_TAG) xorriso/input.t
 
 lorax_repo:
 	git config advice.detachedHead false
-	cd external/lorax && git checkout tags/$(shell cd external/lorax && git tag -l lorax-$(VERSION).* | tail -n 1)
+	cd external/lorax && git checkout tags/$(shell cd external/lorax && git tag -l lorax-$(VERSION).* --sort=creatordate | tail -n 1)
 
 # Step 1: Generate Lorax Templates
 lorax_templates/post_%.tmpl: lorax_templates/scripts/post/%


### PR DESCRIPTION
Building installers based on Fedora 40 is not currently possible because there are changes to the default Lorax templates in Fedora 40 that are not in earlier versions.