### PR TITLE
Pass Flatpak vars directly and let Makefile figure it out from there

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -207,13 +207,6 @@ runs:
         then
           echo "ERROR: flatpak_remote_refs is mutually exclusive to flatpak_remote_refs_dir"
           exit 1
-        else
-          if [[ -n "${{ inputs.flatpak_remote_refs }}" ]]
-          then
-            vars="${vars} FLATPAK_REMOTE_REFS=\"${{ inputs.flatpak_remote_refs }}\""
-          else
-            vars="${vars} FLATPAK_REMOTE_REFS_DIR=\"${{ inputs.flatpak_remote_refs_dir }}\""
-          fi
         fi
         docker run --privileged --volume ${{ github.workspace }}:/github/workspace/ ${cache} ${image}:${tag} \
           ADDITIONAL_TEMPLATES="${{ inputs.additional_templates }}" \
@@ -221,7 +214,8 @@ runs:
           DNF_CACHE="/cache/dnf" \
           ENROLLMENT_PASSWORD="${{ inputs.enrollment_password }}" \
           FLATPAK_REMOTE_NAME="${{ inputs.flatpak_remote_name }}" \
-          ${vars} \
+          FLATPAK_REMOTE_REFS="${{ inputs.flatpak_remote_refs }}" \
+          FLATPAK_REMOTE_REFS_DIR="${{ inputs.flatpak_remote_refs_dir }}" \
           FLATPAK_REMOTE_URL="${{ inputs.flatpak_remote_url }}" \
           FLATPAK_DIR="${{ steps.flatpak_dependencies.outputs.flatpak_dir && format('/github/workspace/{0}', steps.flatpak_dependencies.outputs.flatpak_dir) || '' }}" \
           IMAGE_NAME="${{ inputs.image_name }}" \


### PR DESCRIPTION
The quotes get left in when the options aren't specified. This results in it still trying to treat all files as lists of flatpak refs