### PR TITLE
Remove cache after installing packages

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -19,7 +19,7 @@ VOLUME /build-container-installer/build
 VOLUME /build-container-installer/repos
 VOLUME /cache
 
-RUN dnf install -y make && make install-deps
+RUN dnf install -y make && make install-deps && dnf clean all
 
 ENTRYPOINT ["/bin/bash", "/build-container-installer/entrypoint.sh"]
 


### PR DESCRIPTION
Clean up cache after the packages have been installed so the container image can be smaller.

From testing, this decreases the images by 67MB