### PR TITLE
feat: Allow building from an oci-archive tarball

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,12 @@ _LORAX_TEMPLATES += $(call get_templates,secureboot)
 _TEMPLATE_VARS   += ENROLLMENT_PASSWORD
 endif
 
+ifneq ($(IMAGE_TAR),)
+_IMAGE_TARGET := container/$(IMAGE_NAME)-$(IMAGE_TAG)-tar
+else
+_IMAGE_TARGET := container/$(IMAGE_NAME)-$(IMAGE_TAG)
+endif
+
 _SUBDIRS := container external flatpak_refs lorax_templates repos xorriso test
 
 # Create checksum
@@ -94,7 +100,7 @@ $(ISO_NAME)-CHECKSUM: $(ISO_NAME)
 	cd $(dir $(ISO_NAME)) && sha256sum $(notdir $(ISO_NAME)) > $(notdir $(ISO_NAME))-CHECKSUM
 
 # Build end ISO
-$(ISO_NAME): results/images/boot.iso container/$(IMAGE_NAME)-$(IMAGE_TAG) xorriso/input.txt
+$(ISO_NAME): results/images/boot.iso $(_IMAGE_TARGET) xorriso/input.txt
 	$(if $(wildcard $(dir $(ISO_NAME))),,mkdir -p $(dir $(ISO_NAME)); chmod ugo=rwX $(dir $(ISO_NAME)))
 	xorriso -dialog on < xorriso/input.txt
 	implantisomd5 $(ISO_NAME)

--- a/Makefile.inputs
+++ b/Makefile.inputs
@@ -8,6 +8,7 @@ export IMAGE_NAME              := base
 export IMAGE_REPO              := quay.io/fedora-ostree-desktops
 export IMAGE_TAG                = $(VERSION)
 export IMAGE_SIGNED            := true
+export IMAGE_TAR               :=
        REPOS                   := $(subst :,\:,$(wildcard /etc/yum.repos.d/*.repo))
 export ROOTFS_SIZE             := 4
 export VARIANT                 := Server

--- a/container/Makefile
+++ b/container/Makefile
@@ -1,6 +1,9 @@
 $(IMAGE_NAME)-$(IMAGE_TAG):
 	skopeo copy docker://$(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG) oci:$(IMAGE_NAME)-$(IMAGE_TAG)
 
+$(IMAGE_NAME)-$(IMAGE_TAG)-tar:
+	skopeo copy oci-archive:$(IMAGE_TAR) oci:$(IMAGE_NAME):$(IMAGE_TAG)
+
 install-deps:
 	$(install_pkg) skopeo
 


### PR DESCRIPTION
Hi! I'm the author of the [BlueBuild CLI](https://github.com/blue-build/cli) and I'm [currently working on](https://github.com/blue-build/cli/pull/192) a subcommand to build ISO's locally on a user's machine. We're basically just running your image locally to create the ISO. I had the idea to allow building an ISO from an `oci-archive` tarball so that our users can just build their image to a local tarball and create the ISO so that they wouldn't have to publish their custom image to a registry to do so. Let me know if there's other things you need me to do to get this accepted.