### PR TITLE
Fix `image_src` not setting default value

### DIFF
--- a/.github/workflows/build_iso.yml
+++ b/.github/workflows/build_iso.yml
@@ -119,6 +119,7 @@ jobs:
           iso_name: build/${{ matrix.image_name }}-${{ matrix.version }}${{ matrix.flatpaks == 'false' && '' || format('-{0}', matrix.flatpaks) }}.iso
 
       - name: Upload ISO as artifact
+        if: matrix.version != 'fake'
         id: upload
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build_iso.yml
+++ b/.github/workflows/build_iso.yml
@@ -107,6 +107,7 @@ jobs:
           arch: ${{ needs.load_vars.outputs.ARCH }}
           image_name: ${{ matrix.image_name }}
           image_repo: ${{ matrix.image_repo}}
+          image_src: ${{ matrix.image_src }}
           image_tag: ${{ matrix.version }}
           version: ${{ matrix.version }}
           repos: ${{ matrix.repos }}

--- a/.github/workflows/build_vars.yml
+++ b/.github/workflows/build_vars.yml
@@ -37,6 +37,12 @@ on:
                 "version": "40",
                 "image_repo": "quay.io/fedora",
                 "image_name": "fedora-bootc"
+              },
+              {
+                "version": "40",
+                "image_repo": "quay.io/fedora",
+                "image_name": "fedora-bootc",
+                "image_src": "docker://quay.io/fedora-ostree-desktops/base:39"
               }
             ]
           }'

--- a/.github/workflows/build_vars.yml
+++ b/.github/workflows/build_vars.yml
@@ -39,7 +39,7 @@ on:
                 "image_name": "fedora-bootc"
               },
               {
-                "version": "40",
+                "version": "fake",
                 "image_repo": "quay.io/fedora",
                 "image_name": "fedora-bootc",
                 "image_src": "docker://quay.io/fedora-ostree-desktops/base:39"

--- a/container/Makefile
+++ b/container/Makefile
@@ -1,9 +1,5 @@
-ifeq ($(IMAGE_SRC),)
-IMAGE_SRC += docker://$(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG)
-endif
-
 $(IMAGE_NAME)-$(IMAGE_TAG):
-	skopeo copy $(IMAGE_SRC) oci:$(IMAGE_NAME)-$(IMAGE_TAG)
+	skopeo copy $(if $(IMAGE_SRC),$(IMAGE_SRC),docker://$(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG)) oci:$(IMAGE_NAME)-$(IMAGE_TAG)
 
 install-deps:
 	$(install_pkg) skopeo

--- a/container/Makefile
+++ b/container/Makefile
@@ -1,5 +1,5 @@
 ifeq ($(IMAGE_SRC),)
-IMAGE_SRC := docker://$(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG)
+IMAGE_SRC += docker://$(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG)
 endif
 
 $(IMAGE_NAME)-$(IMAGE_TAG):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved CI/CD workflow by adding a new `image_src` parameter for job configuration.
  - Streamlined container build process by integrating `IMAGE_SRC` directly into the `skopeo copy` command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->