### PR TITLE
Update .gitmodules from f39 to f40

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "external/fedora-lorax-templates"]
 	path = external/fedora-lorax-templates
 	url = https://pagure.io/fedora-lorax-templates.git
-	branch = f39
+	branch = f40
 [submodule "external/lorax"]
 	path = external/lorax
 	url = https://github.com/weldr/lorax.git


### PR DESCRIPTION
just update branch from f39 to f40 for fedora-lorax-templates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated submodule `external/fedora-lorax-templates` branch from `f39` to `f40`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->