### PR TITLE
Tag image with long sha

### DIFF
--- a/.github/workflows/build_container.yml
+++ b/.github/workflows/build_container.yml
@@ -72,6 +72,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
+            type=sha,format=long
             type=semver,pattern=v{{version}}
             type=semver,pattern=v{{major}}.{{minor}}
             type=semver,pattern=v{{major}}.{{minor}}.{{patch}}

--- a/.github/workflows/build_container.yml
+++ b/.github/workflows/build_container.yml
@@ -72,7 +72,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=sha,format=long
+            type=raw,value=${{ github.sha }}
             type=semver,pattern=v{{version}}
             type=semver,pattern=v{{major}}.{{minor}}
             type=semver,pattern=v{{major}}.{{minor}}.{{patch}}


### PR DESCRIPTION
Fixes #134 

I have not been able to test this myself, but according to the [documentation](https://github.com/docker/metadata-action#typesha), this should work.

This allows us to pin to a specific git hash, rather than being on a mutable reference.