### PR TITLE
Truncate VOLID at 32 characters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ _LORAX_TEMPLATES           := $(call get_templates,install)
 _REPO_FILES                := $(subst /etc/yum.repos.d,repos,$(REPOS))
 _TEMP_DIR                  := $(shell mktemp -d)
 _TEMPLATE_VARS             := ARCH IMAGE_NAME IMAGE_REPO _IMAGE_REPO_DOUBLE_ESCAPED _IMAGE_REPO_ESCAPED IMAGE_SIGNED IMAGE_TAG REPOS _RHEL VARIANT VERSION WEB_UI
-_VOLID                     := $(firstword $(subst -, ,$(IMAGE_NAME)))-$(ARCH)-$(IMAGE_TAG)
+_VOLID                     := $(shell echo "$(firstword $(subst -, ,$(IMAGE_NAME)))-$(ARCH)-$(IMAGE_TAG)" | cut -c 1-32)
 
 ifeq ($(findstring redhat.repo,$(REPOS)),redhat.repo)
 export _RHEL := true


### PR DESCRIPTION
Fixes: #139 by preventing the volume id from being longer than 32 characters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Enhanced the construction of the `_VOLID` variable to ensure it adheres to a maximum length of 32 characters for better compatibility with other systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->