### PR TITLE
fix: link to inputs

### DIFF
--- a/docs/development/container.md
+++ b/docs/development/container.md
@@ -6,7 +6,7 @@ To use the container file, run `podman run --privileged --volume .:/build-contai
 
 This will create an ISO with the baked in defaults of the container image. The resulting file will be called `deploy.iso`
 
-See [Inputs](../usage.md#inputs) for information about customizing the ISO that gets created. The variables can be defined as environment variables or command arguments. All variables should be specified in CAPITALIZED form.
+See [Inputs](usage.md#inputs) for information about customizing the ISO that gets created. The variables can be defined as environment variables or command arguments. All variables should be specified in CAPITALIZED form.
 Examples:
 
 Building an ISO to install Fedora 39

--- a/docs/development/makefile.md
+++ b/docs/development/makefile.md
@@ -4,4 +4,4 @@ The Makefile contains all the commands that are run in the action. There are sep
 
 `make install-deps` can be used to install the necessary packages.
 
-See [Inputs](../usage.md#inputs) for information about the available parameters. All variables should be specified in CAPITALIZED form.
+See [Inputs](../wiki/usage#inputs) for information about the available parameters. All variables should be specified in CAPITALIZED form.

--- a/docs/development/makefile.md
+++ b/docs/development/makefile.md
@@ -4,4 +4,4 @@ The Makefile contains all the commands that are run in the action. There are sep
 
 `make install-deps` can be used to install the necessary packages.
 
-See [Inputs](../wiki/usage#inputs) for information about the available parameters. All variables should be specified in CAPITALIZED form.
+See [Inputs](usage#inputs) for information about the available parameters. All variables should be specified in CAPITALIZED form.


### PR DESCRIPTION
Currently goes to a dead link, fixed by adding /wiki and removing .md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated hyperlinks in the container and Makefile documentation for improved navigation.
	- Retained existing content and instructions for using the container with `podman` and building ISOs for Fedora versions 39 and 40.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->