### PR TITLE
Block broken lorax versions

### DIFF
--- a/.github/workflows/build_iso.yml
+++ b/.github/workflows/build_iso.yml
@@ -53,7 +53,7 @@ jobs:
         id: jobs
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          job_name: "${{ inputs.parent_job_name }} / ${{ env.JOB_NAME }} (${{ matrix.version }}, ${{ matrix.flatpaks }}, ${{ matrix.image_repo }}, ${{ image_name }})"
+          job_name: "${{ inputs.parent_job_name }} / ${{ env.JOB_NAME }} (${{ matrix.version }}, ${{ matrix.flatpaks }}, ${{ matrix.image_repo }}, ${{ matrix.image_name }})"
           per_page: 100
 
       - name: Set status
@@ -62,7 +62,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           status: pending
-          context: "${{ inputs.parent_job_name }} / ${{ env.JOB_NAME }} (${{ matrix.version }}, ${{ matrix.flatpaks }}, ${{ matrix.image_repo }}, ${{ image_name }})"
+          context: "${{ inputs.parent_job_name }} / ${{ env.JOB_NAME }} (${{ matrix.version }}, ${{ matrix.flatpaks }}, ${{ matrix.image_repo }}, ${{ matrix.image_name }})"
           sha: ${{ env.sha }}
           targetUrl: ${{ steps.jobs.outputs.html_url }}
 
@@ -138,7 +138,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           status: ${{ job.status }}
-          context: "${{ inputs.parent_job_name }} / ${{ env.JOB_NAME }} (${{ matrix.version }}, ${{ matrix.flatpaks }}, ${{ matrix.image_repo }}, ${{ image_name }})"
+          context: "${{ inputs.parent_job_name }} / ${{ env.JOB_NAME }} (${{ matrix.version }}, ${{ matrix.flatpaks }}, ${{ matrix.image_repo }}, ${{ matrix.image_name }})"
           sha: ${{ env.sha }}
           targetUrl: ${{ steps.jobs.outputs.html_url }}
 

--- a/.github/workflows/build_iso.yml
+++ b/.github/workflows/build_iso.yml
@@ -53,7 +53,7 @@ jobs:
         id: jobs
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          job_name: "${{ inputs.parent_job_name }} / ${{ env.JOB_NAME }} (${{ matrix.version }}, ${{ matrix.flatpaks }})"
+          job_name: "${{ inputs.parent_job_name }} / ${{ env.JOB_NAME }} (${{ matrix.version }}, ${{ matrix.flatpaks }}, ${{ matrix.image_repo }}, ${{ image_name }})"
           per_page: 100
 
       - name: Set status
@@ -62,7 +62,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           status: pending
-          context: "${{ inputs.parent_job_name }} / ${{ env.JOB_NAME }} (${{ matrix.version }}, ${{ matrix.flatpaks }})"
+          context: "${{ inputs.parent_job_name }} / ${{ env.JOB_NAME }} (${{ matrix.version }}, ${{ matrix.flatpaks }}, ${{ matrix.image_repo }}, ${{ image_name }})"
           sha: ${{ env.sha }}
           targetUrl: ${{ steps.jobs.outputs.html_url }}
 
@@ -138,7 +138,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           status: ${{ job.status }}
-          context: "${{ inputs.parent_job_name }} / ${{ env.JOB_NAME }} (${{ matrix.version }}, ${{ matrix.flatpaks }})"
+          context: "${{ inputs.parent_job_name }} / ${{ env.JOB_NAME }} (${{ matrix.version }}, ${{ matrix.flatpaks }}, ${{ matrix.image_repo }}, ${{ image_name }})"
           sha: ${{ env.sha }}
           targetUrl: ${{ steps.jobs.outputs.html_url }}
 

--- a/.github/workflows/test_deployment.yml
+++ b/.github/workflows/test_deployment.yml
@@ -52,7 +52,7 @@ jobs:
         id: jobs
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          job_name: "${{ inputs.parent_job_name }} / ${{ env.JOB_NAME }} (${{ matrix.version }}, ${{ matrix.flatpaks }})"
+          job_name: "${{ inputs.parent_job_name }} / ${{ env.JOB_NAME }} (${{ matrix.version }}, ${{ matrix.flatpaks }}, ${{ matrix.image_repo }}, ${{ image_name }})"
           per_page: 100
 
       - name: Set status
@@ -61,7 +61,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           status: pending
-          context: "${{ inputs.parent_job_name }} / ${{ env.JOB_NAME }} (${{ matrix.version }}, ${{ matrix.flatpaks }})"
+          context: "${{ inputs.parent_job_name }} / ${{ env.JOB_NAME }} (${{ matrix.version }}, ${{ matrix.flatpaks }}, ${{ matrix.image_repo }}, ${{ image_name }})"
           sha: ${{ env.sha }}
           targetUrl: ${{ steps.jobs.outputs.html_url }}
 
@@ -107,6 +107,6 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           status: ${{ job.status }}
-          context: "${{ inputs.parent_job_name }} / ${{ env.JOB_NAME }} (${{ matrix.version }}, ${{ matrix.flatpaks }})"
+          context: "${{ inputs.parent_job_name }} / ${{ env.JOB_NAME }} (${{ matrix.version }}, ${{ matrix.flatpaks }}, ${{ matrix.image_repo }}, ${{ image_name }})"
           sha: ${{ env.sha }}
           targetUrl: ${{ steps.jobs.outputs.html_url }}

--- a/.github/workflows/test_deployment.yml
+++ b/.github/workflows/test_deployment.yml
@@ -52,7 +52,7 @@ jobs:
         id: jobs
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          job_name: "${{ inputs.parent_job_name }} / ${{ env.JOB_NAME }} (${{ matrix.version }}, ${{ matrix.flatpaks }}, ${{ matrix.image_repo }}, ${{ image_name }})"
+          job_name: "${{ inputs.parent_job_name }} / ${{ env.JOB_NAME }} (${{ matrix.version }}, ${{ matrix.flatpaks }}, ${{ matrix.image_repo }}, ${{ matrix.image_name }})"
           per_page: 100
 
       - name: Set status
@@ -61,7 +61,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           status: pending
-          context: "${{ inputs.parent_job_name }} / ${{ env.JOB_NAME }} (${{ matrix.version }}, ${{ matrix.flatpaks }}, ${{ matrix.image_repo }}, ${{ image_name }})"
+          context: "${{ inputs.parent_job_name }} / ${{ env.JOB_NAME }} (${{ matrix.version }}, ${{ matrix.flatpaks }}, ${{ matrix.image_repo }}, ${{ matrix.image_name }})"
           sha: ${{ env.sha }}
           targetUrl: ${{ steps.jobs.outputs.html_url }}
 
@@ -107,6 +107,6 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           status: ${{ job.status }}
-          context: "${{ inputs.parent_job_name }} / ${{ env.JOB_NAME }} (${{ matrix.version }}, ${{ matrix.flatpaks }}, ${{ matrix.image_repo }}, ${{ image_name }})"
+          context: "${{ inputs.parent_job_name }} / ${{ env.JOB_NAME }} (${{ matrix.version }}, ${{ matrix.flatpaks }}, ${{ matrix.image_repo }}, ${{ matrix.image_name }})"
           sha: ${{ env.sha }}
           targetUrl: ${{ steps.jobs.outputs.html_url }}

--- a/.github/workflows/test_iso.yml
+++ b/.github/workflows/test_iso.yml
@@ -52,7 +52,7 @@ jobs:
         id: jobs
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          job_name: "${{ inputs.parent_job_name }} / ${{ env.JOB_NAME }} (${{ matrix.version }}, ${{ matrix.flatpaks }})"
+          job_name: "${{ inputs.parent_job_name }} / ${{ env.JOB_NAME }} (${{ matrix.version }}, ${{ matrix.flatpaks }}, ${{ matrix.image_repo }}, ${{ image_name }})"
           per_page: 100
 
       - name: Set status
@@ -61,7 +61,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           status: pending
-          context: "${{ inputs.parent_job_name }} / ${{ env.JOB_NAME }} (${{ matrix.version }}, ${{ matrix.flatpaks }})"
+          context: "${{ inputs.parent_job_name }} / ${{ env.JOB_NAME }} (${{ matrix.version }}, ${{ matrix.flatpaks }}, ${{ matrix.image_repo }}, ${{ image_name }})"
           sha: ${{ env.sha }}
           targetUrl: ${{ steps.jobs.outputs.html_url }}
 
@@ -98,6 +98,6 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           status: ${{ job.status }}
-          context: "${{ inputs.parent_job_name }} / ${{ env.JOB_NAME }} (${{ matrix.version }}, ${{ matrix.flatpaks }})"
+          context: "${{ inputs.parent_job_name }} / ${{ env.JOB_NAME }} (${{ matrix.version }}, ${{ matrix.flatpaks }}, ${{ matrix.image_repo }}, ${{ image_name }})"
           sha: ${{ env.sha }}
           targetUrl: ${{ steps.jobs.outputs.html_url }}

--- a/.github/workflows/test_iso.yml
+++ b/.github/workflows/test_iso.yml
@@ -52,7 +52,7 @@ jobs:
         id: jobs
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          job_name: "${{ inputs.parent_job_name }} / ${{ env.JOB_NAME }} (${{ matrix.version }}, ${{ matrix.flatpaks }}, ${{ matrix.image_repo }}, ${{ image_name }})"
+          job_name: "${{ inputs.parent_job_name }} / ${{ env.JOB_NAME }} (${{ matrix.version }}, ${{ matrix.flatpaks }}, ${{ matrix.image_repo }}, ${{ matrix.image_name }})"
           per_page: 100
 
       - name: Set status
@@ -61,7 +61,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           status: pending
-          context: "${{ inputs.parent_job_name }} / ${{ env.JOB_NAME }} (${{ matrix.version }}, ${{ matrix.flatpaks }}, ${{ matrix.image_repo }}, ${{ image_name }})"
+          context: "${{ inputs.parent_job_name }} / ${{ env.JOB_NAME }} (${{ matrix.version }}, ${{ matrix.flatpaks }}, ${{ matrix.image_repo }}, ${{ matrix.image_name }})"
           sha: ${{ env.sha }}
           targetUrl: ${{ steps.jobs.outputs.html_url }}
 
@@ -98,6 +98,6 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           status: ${{ job.status }}
-          context: "${{ inputs.parent_job_name }} / ${{ env.JOB_NAME }} (${{ matrix.version }}, ${{ matrix.flatpaks }}, ${{ matrix.image_repo }}, ${{ image_name }})"
+          context: "${{ inputs.parent_job_name }} / ${{ env.JOB_NAME }} (${{ matrix.version }}, ${{ matrix.flatpaks }}, ${{ matrix.image_repo }}, ${{ matrix.image_name }})"
           sha: ${{ env.sha }}
           targetUrl: ${{ steps.jobs.outputs.html_url }}

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,6 @@ results/images/boot.iso: external/lorax/branch-$(VERSION) $(filter lorax_templat
 
 	lorax -p $(IMAGE_NAME) -v $(VERSION) -r $(VERSION) -t $(VARIANT) \
 		--isfinal --buildarch=$(ARCH) --volid=$(_VOLID) --sharedir $(PWD)/external/lorax/share/templates.d/99-generic \
-		--installpkgs glibc \
 		$(_LORAX_ARGS) \
 		$(foreach file,$(_REPO_FILES),--repo $(patsubst repos/%,$(PWD)/repos/%,$(file))) \
 		$(foreach file,$(_LORAX_TEMPLATES),--add-template $(PWD)/$(file)) \

--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,7 @@ results/images/boot.iso: external/lorax/branch-$(VERSION) $(filter lorax_templat
 
 	lorax -p $(IMAGE_NAME) -v $(VERSION) -r $(VERSION) -t $(VARIANT) \
 		--isfinal --buildarch=$(ARCH) --volid=$(_VOLID) --sharedir $(PWD)/external/lorax/share/templates.d/99-generic \
+		--installpkgs python3-pyudev \
 		$(_LORAX_ARGS) \
 		$(foreach file,$(_REPO_FILES),--repo $(patsubst repos/%,$(PWD)/repos/%,$(file))) \
 		$(foreach file,$(_LORAX_TEMPLATES),--add-template $(PWD)/$(file)) \

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ results/images/boot.iso: external/lorax/branch-$(VERSION) $(filter lorax_templat
 
 	lorax -p $(IMAGE_NAME) -v $(VERSION) -r $(VERSION) -t $(VARIANT) \
 		--isfinal --buildarch=$(ARCH) --volid=$(_VOLID) --sharedir $(PWD)/external/lorax/share/templates.d/99-generic \
-		--installpkgs python3-pyudev \
+		--installpkgs glibc \
 		$(_LORAX_ARGS) \
 		$(foreach file,$(_REPO_FILES),--repo $(patsubst repos/%,$(PWD)/repos/%,$(file))) \
 		$(foreach file,$(_LORAX_TEMPLATES),--add-template $(PWD)/$(file)) \

--- a/external/Makefile
+++ b/external/Makefile
@@ -1,6 +1,6 @@
 lorax/branch-$(VERSION):
 	git config advice.detachedHead false
-	cd lorax && git reset --hard HEAD && git checkout $(if $(_RHEL),rhel$(word 1,$(subst ., ,$(VERSION)))-branch,tags/$(shell cd lorax && git tag -l lorax-$(VERSION).* --sort=creatordate | grep -v 'lorax-40.5.10-1' | tail -n 1))
+	cd lorax && git reset --hard HEAD && git checkout $(if $(_RHEL),rhel$(word 1,$(subst ., ,$(VERSION)))-branch,tags/$(shell cd lorax && git tag -l lorax-$(VERSION).* --sort=creatordate | grep -v 'lorax-40.5' | tail -n 1))
 	touch lorax/branch-$(VERSION)
 
 install-deps:

--- a/external/Makefile
+++ b/external/Makefile
@@ -1,6 +1,6 @@
 lorax/branch-$(VERSION):
 	git config advice.detachedHead false
-	cd lorax && git reset --hard HEAD && git checkout $(if $(_RHEL),rhel$(word 1,$(subst ., ,$(VERSION)))-branch,tags/$(shell cd lorax && git tag -l lorax-$(VERSION).* --sort=creatordate | tail -n 1))
+	cd lorax && git reset --hard HEAD && git checkout $(if $(_RHEL),rhel$(word 1,$(subst ., ,$(VERSION)))-branch,tags/$(shell cd lorax && git tag -l lorax-$(VERSION).* --sort=creatordate | grep -v 'lorax-40.5.10-1' | tail -n 1))
 	touch lorax/branch-$(VERSION)
 
 install-deps:

--- a/external/Makefile
+++ b/external/Makefile
@@ -1,6 +1,6 @@
 lorax/branch-$(VERSION):
 	git config advice.detachedHead false
-	cd lorax && git reset --hard HEAD && git checkout $(if $(_RHEL),rhel$(word 1,$(subst ., ,$(VERSION)))-branch,tags/$(shell cd lorax && git tag -l lorax-$(VERSION).* --sort=creatordate | grep -v 'lorax-40.5' | tail -n 1))
+	cd lorax && git reset --hard HEAD && git checkout $(if $(_RHEL),rhel$(word 1,$(subst ., ,$(VERSION)))-branch,tags/$(shell cd lorax && git tag -l lorax-$(VERSION).* --sort=creatordate | grep -v 'lorax-40\.5' | tail -n 1))
 	touch lorax/branch-$(VERSION)
 
 install-deps:


### PR DESCRIPTION
Some versions of lorax will remove all files installed by the package `glibc` into the directory `/usr/sbin`. This results in `/sbin/ldconfig` being removed because `/sbin` is a link to `/usr/sbin`. pyudev uses `ctypes.util.find_library` to find libudev and that function uses /sbin/ldconfig -p` to find the library.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Workflow Updates**
	- Enhanced GitHub Actions workflows for build, test, and deployment processes
	- Improved job logging and context tracking by adding image repository and name details

- **Build Configuration**
	- Updated Makefile to modify tag selection logic for lorax checkout
	- Excluded specific tag from automatic selection process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->