### PR TITLE
Add tests for Fedora 43

### DIFF
--- a/.github/workflows/build_vars.yml
+++ b/.github/workflows/build_vars.yml
@@ -9,9 +9,9 @@ on:
         value: '
           {
             "version": [
-              "40",
               "41",
-              "42"
+              "42",
+              "43"
             ],
             "flatpaks": [
               "false",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated build pipeline to target versions 41–43 (dropping 40 and adding 43), aligning with current platform/runtime support and maintaining coverage for latest releases.
  - This change improves CI reliability and release readiness for newer versions.
  - No changes to user-facing behavior, settings, or documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->