### PR TITLE
Make webui default installer

### DIFF
--- a/Makefile.inputs
+++ b/Makefile.inputs
@@ -13,7 +13,7 @@ export IMAGE_SIGNED            := true
 export ROOTFS_SIZE             := 4
 export VARIANT                 := Server
 export VERSION                 := 39
-export WEB_UI                  := false
+export WEB_UI                  := true
 # Flatpak
 export FLATPAK_REMOTE_NAME     := flathub
 export FLATPAK_REMOTE_URL      := https://flathub.org/repo/flathub.flatpakrepo

--- a/action.yml
+++ b/action.yml
@@ -99,7 +99,7 @@ inputs:
   web_ui:
     description: Enable Anaconda WebUI
     required: false
-    default: "false"
+    default: "true"
 
 outputs:
   iso_name:


### PR DESCRIPTION
Fixes #183 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Web UI is now enabled by default in the build configuration.
  * Web UI is now enabled by default for the repository's composite action inputs, so it will be active unless explicitly turned off.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->