### PR TITLE
Switch to bazzite for tests

### DIFF
--- a/.github/workflows/build_iso.yml
+++ b/.github/workflows/build_iso.yml
@@ -108,7 +108,7 @@ jobs:
           image_name: ${{ matrix.image_name }}
           image_repo: ${{ matrix.image_repo}}
           image_src: ${{ matrix.image_src }}
-          image_tag: ${{ matrix.version }}
+          image_tag: ${{ matrix.prefix }}${{ matrix.version }}
           version: ${{ matrix.version }}
           repos: ${{ matrix.repos }}
           variant: ${{ needs.load_vars.outputs.VARIANT }}

--- a/.github/workflows/build_vars.yml
+++ b/.github/workflows/build_vars.yml
@@ -25,15 +25,18 @@ on:
             "include": [
               {
                 "image_repo": "ghcr.io/ublue-os",
-                "image_name": "base-main",
+                "image_name": "bazzite",
+                "prefix": "stable-"
               },
               {
                 "image_repo": "quay.io/fedora",
-                "image_name": "fedora-bootc"
+                "image_name": "fedora-bootc",
+                "prefix": ""
               },
               {
                 "image_repo": "quay.io/fedora-ostree-desktops",
-                "image_name": "base-atomic"
+                "image_name": "base-atomic",
+                "prefix": ""
               }
             ],
             "exclude": [
@@ -52,10 +55,6 @@ on:
               {
                 "image_repo": "quay.io/fedora-ostree-desktops",
                 "flatpaks": "flatpak_refs"
-              },
-              {
-                "image_repo": "ghcr.io/ublue-os",
-                "version": "43"
               }
             ]
           }'


### PR DESCRIPTION
Main has too many layers to allow for a pull.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated build inputs so the correct image variants are used during ISO creation.
  * Improved build matrix handling to include the intended Fedora and Bazzite variants more consistently.
  * Removed an outdated build restriction, allowing the affected version to be built normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->