### PR TITLE
Allow for images with more than 128 layers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ $(ISO_NAME)-CHECKSUM: $(ISO_NAME)
 	cd $(dir $(ISO_NAME)) && sha256sum $(notdir $(ISO_NAME)) > $(notdir $(ISO_NAME))-CHECKSUM
 
 # Build end ISO
-$(ISO_NAME): results/images/boot.iso container/$(IMAGE_NAME)-$(IMAGE_TAG) xorriso/input.txt
+$(ISO_NAME): results/images/boot.iso container/$(IMAGE_NAME) xorriso/input.txt
 	$(if $(wildcard $(dir $(ISO_NAME))),,mkdir -p $(dir $(ISO_NAME)); chmod ugo=rwX $(dir $(ISO_NAME)))
 	xorriso -dialog on < xorriso/input.txt
 	implantisomd5 $(ISO_NAME)

--- a/action.yml
+++ b/action.yml
@@ -154,8 +154,9 @@ runs:
       shell: bash
       run: |
         cd ${{ github.action_path }}
-        make container/install-deps install_pkg="apt install -y"
-        make flatpaks/install-deps install_pkg="apt install -y"
+        sudo apt update
+        sudo make container/install-deps install_pkg="apt install -y"
+        sudo make flatpaks/install-deps install_pkg="apt install -y"
         make flatpaks/repo \
           FLATPAK_REMOTE_NAME="${{ inputs.flatpak_remote_name }}" \
           ${{ inputs.flatpak_remote_refs && format('FLATPAK_REMOTE_REFS="{0}"', inputs.flatpak_remote_refs) || ''}} \

--- a/action.yml
+++ b/action.yml
@@ -157,6 +157,11 @@ runs:
         sudo apt update
         sudo make container/install-deps install_pkg="apt install -y"
         sudo make flatpaks/install-deps install_pkg="apt install -y"
+        sudo make container/${{ inputs.image_name }}-${{ inputs.image_tag || inputs.version }}.tar \
+          IMAGE_NAME="${{ inputs.image_name }}" \
+          IMAGE_REPO="${{ inputs.image_repo }}" \
+          IMAGE_SRC="${{ inputs.image_src }}" \
+          IMAGE_TAG="${{ inputs.image_tag || inputs.version }}"
         make flatpaks/repo \
           FLATPAK_REMOTE_NAME="${{ inputs.flatpak_remote_name }}" \
           ${{ inputs.flatpak_remote_refs && format('FLATPAK_REMOTE_REFS="{0}"', inputs.flatpak_remote_refs) || ''}} \

--- a/action.yml
+++ b/action.yml
@@ -154,6 +154,7 @@ runs:
       shell: bash
       run: |
         cd ${{ github.action_path }}
+        make install-deps
         make flatpaks/repo \
           FLATPAK_REMOTE_NAME="${{ inputs.flatpak_remote_name }}" \
           ${{ inputs.flatpak_remote_refs && format('FLATPAK_REMOTE_REFS="{0}"', inputs.flatpak_remote_refs) || ''}} \

--- a/action.yml
+++ b/action.yml
@@ -154,7 +154,8 @@ runs:
       shell: bash
       run: |
         cd ${{ github.action_path }}
-        make install-deps
+        make container/install-deps install_pkg="apt install -y"
+        make flatpaks/install-deps install_pkg="apt install -y"
         make flatpaks/repo \
           FLATPAK_REMOTE_NAME="${{ inputs.flatpak_remote_name }}" \
           ${{ inputs.flatpak_remote_refs && format('FLATPAK_REMOTE_REFS="{0}"', inputs.flatpak_remote_refs) || ''}} \

--- a/container/Makefile
+++ b/container/Makefile
@@ -2,6 +2,7 @@ $(IMAGE_NAME):
 	skopeo copy $(if $(IMAGE_SRC),$(IMAGE_SRC),docker://$(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG)) oci:$(IMAGE_NAME):$(IMAGE_TAG)
 
 $(IMAGE_NAME)-$(IMAGE_TAG).tar: $(IMAGE_NAME)
+	if [ -d image_root ]; then rm -Rf image_root; fi
 	umoci unpack --rootless --image $(IMAGE_NAME):$(IMAGE_TAG) image_root
 	tar -C image_root/rootfs -cf $(IMAGE_NAME)-$(IMAGE_TAG).tar .
 

--- a/container/Makefile
+++ b/container/Makefile
@@ -1,8 +1,12 @@
 $(IMAGE_NAME)-$(IMAGE_TAG):
 	skopeo copy $(if $(IMAGE_SRC),$(IMAGE_SRC),docker://$(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG)) oci:$(IMAGE_NAME)-$(IMAGE_TAG)
 
+$(IMAGE_NAME)-$(IMAGE_TAG).tar: $(IMAGE_NAME)-$(IMAGE_TAG)
+	umoci unpack --rootless --image $(IMAGE_NAME)-$(IMAGE_TAG) image_root
+	tar -C image_root/rootfs -cf $(IMAGE_NAME)-$(IMAGE_TAG).tar
+
 install-deps:
-	$(install_pkg) skopeo
+	$(install_pkg) skopeo umoci
 
 FILES=$(filter-out Makefile,$(wildcard *))
 clean:

--- a/container/Makefile
+++ b/container/Makefile
@@ -2,11 +2,12 @@ $(IMAGE_NAME)-$(IMAGE_TAG):
 	skopeo copy $(if $(IMAGE_SRC),$(IMAGE_SRC),docker://$(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG)) oci:$(IMAGE_NAME)-$(IMAGE_TAG)
 
 $(IMAGE_NAME)-$(IMAGE_TAG).tar: $(IMAGE_NAME)-$(IMAGE_TAG)
-	umoci unpack --rootless --image $(IMAGE_NAME)-$(IMAGE_TAG) image_root
+
+	umoci unpack --rootless --image $(IMAGE_NAME)-$(IMAGE_TAG)@$(shell jq -r '.manifests[0].digest' ../container/$(IMAGE_NAME)-$(IMAGE_TAG)/index.json) image_root
 	tar -C image_root/rootfs -cf $(IMAGE_NAME)-$(IMAGE_TAG).tar
 
 install-deps:
-	$(install_pkg) skopeo umoci
+	$(install_pkg) skopeo umoci jq
 
 FILES=$(filter-out Makefile,$(wildcard *))
 clean:

--- a/container/Makefile
+++ b/container/Makefile
@@ -1,10 +1,9 @@
-$(IMAGE_NAME)-$(IMAGE_TAG):
-	skopeo copy $(if $(IMAGE_SRC),$(IMAGE_SRC),docker://$(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG)) oci:$(IMAGE_NAME)-$(IMAGE_TAG)
+$(IMAGE_NAME):
+	skopeo copy $(if $(IMAGE_SRC),$(IMAGE_SRC),docker://$(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG)) oci:$(IMAGE_NAME):$(IMAGE_TAG)
 
-$(IMAGE_NAME)-$(IMAGE_TAG).tar: $(IMAGE_NAME)-$(IMAGE_TAG)
-
-	umoci unpack --rootless --image $(IMAGE_NAME)-$(IMAGE_TAG)@$(shell jq -r '.manifests[0].digest' ../container/$(IMAGE_NAME)-$(IMAGE_TAG)/index.json) image_root
-	tar -C image_root/rootfs -cf $(IMAGE_NAME)-$(IMAGE_TAG).tar
+$(IMAGE_NAME)-$(IMAGE_TAG).tar: $(IMAGE_NAME)
+	umoci unpack --rootless --image $(IMAGE_NAME):$(IMAGE_TAG) image_root
+	tar -C image_root/rootfs -cf $(IMAGE_NAME)-$(IMAGE_TAG).tar .
 
 install-deps:
 	$(install_pkg) skopeo umoci jq

--- a/flatpaks/Makefile
+++ b/flatpaks/Makefile
@@ -42,7 +42,7 @@ clean:
 	$(if $(wildcard list.txt),rm list.txt)
 
 container-%:
-    $(MAKE) -C ../container $*
+	$(MAKE) -C ../container $*
 
 .ONESHELL:
 .SHELLFLAGS := -ec

--- a/flatpaks/Makefile
+++ b/flatpaks/Makefile
@@ -8,6 +8,8 @@ full_list: repo
 
 repo: script.sh
 	$(if $(GITHUB_WORKSPACE),cp script.sh $(FLATPAK_DIR)/)
+	skopeo copy docker://$(IMAGE) docker-archive:image.tar
+	docker import image.tar $(IMAGE)
 	docker run --rm --privileged --entrypoint bash -e FLATPAK_SYSTEM_DIR=/flatpak/flatpak -e FLATPAK_TRIGGERSDIR=/flatpak/triggers --volume $(FLATPAK_DIR):/flatpak_dir $(IMAGE) /flatpak_dir/script.sh
 	$(if $(GITHUB_OUTPUT),echo "flatpak_dir=$(subst $(GITHUB_WORKSPACE)/,,$(FLATPAK_DIR))" >> $(GITHUB_OUTPUT))
 	docker rmi $(IMAGE)

--- a/flatpaks/Makefile
+++ b/flatpaks/Makefile
@@ -6,7 +6,7 @@ full_list: repo
 	cat $(FLATPAK_DIR)/list.txt >&2
 	
 
-repo: script.sh ../container/$(IMAGE_NAME)-$(IMAGE_TAG).tar
+repo: script.sh container-$(IMAGE_NAME)-$(IMAGE_TAG).tar
 	$(if $(GITHUB_WORKSPACE),cp script.sh $(FLATPAK_DIR)/)
 	docker import ../container/$(IMAGE_NAME)-$(IMAGE_TAG).tar $(IMAGE)
 	docker run --rm --privileged --entrypoint bash -e FLATPAK_SYSTEM_DIR=/flatpak/flatpak -e FLATPAK_TRIGGERSDIR=/flatpak/triggers --volume $(FLATPAK_DIR):/flatpak_dir $(IMAGE) /flatpak_dir/script.sh
@@ -40,6 +40,9 @@ clean:
 	$(if $(wildcard script.sh),rm script.sh)
 	$(if $(wildcard repo),rm -Rf repo)
 	$(if $(wildcard list.txt),rm list.txt)
+
+container-%:
+    $(MAKE) -C ../container $*
 
 .ONESHELL:
 .SHELLFLAGS := -ec

--- a/flatpaks/Makefile
+++ b/flatpaks/Makefile
@@ -6,10 +6,9 @@ full_list: repo
 	cat $(FLATPAK_DIR)/list.txt >&2
 	
 
-repo: script.sh
+repo: script.sh ../container/$(IMAGE_NAME)-$(IMAGE_TAG).tar
 	$(if $(GITHUB_WORKSPACE),cp script.sh $(FLATPAK_DIR)/)
-	skopeo copy docker://$(IMAGE) docker-archive:image.tar
-	docker import image.tar $(IMAGE)
+	docker import ../container/$(IMAGE_NAME)-$(IMAGE_TAG).tar $(IMAGE)
 	docker run --rm --privileged --entrypoint bash -e FLATPAK_SYSTEM_DIR=/flatpak/flatpak -e FLATPAK_TRIGGERSDIR=/flatpak/triggers --volume $(FLATPAK_DIR):/flatpak_dir $(IMAGE) /flatpak_dir/script.sh
 	$(if $(GITHUB_OUTPUT),echo "flatpak_dir=$(subst $(GITHUB_WORKSPACE)/,,$(FLATPAK_DIR))" >> $(GITHUB_OUTPUT))
 	docker rmi $(IMAGE)
@@ -43,3 +42,4 @@ clean:
 	$(if $(wildcard list.txt),rm list.txt)
 
 .ONESHELL:
+.SHELLFLAGS := -ec

--- a/lorax_templates/install_set_installer.tmpl
+++ b/lorax_templates/install_set_installer.tmpl
@@ -1,4 +1,4 @@
-<%page args="image_name, image_tag"/>
+<%page args="image_name"/>
 
-append usr/share/anaconda/interactive-defaults.ks "ostreecontainer --url=/run/install/repo/${image_name}-${image_tag} --transport=oci --no-signature-verification"
+append usr/share/anaconda/interactive-defaults.ks "ostreecontainer --url=/run/install/repo/${image_name} --transport=oci --no-signature-verification"
 

--- a/xorriso/gen_input.sh
+++ b/xorriso/gen_input.sh
@@ -25,7 +25,7 @@ popd > /dev/null
 if [[ -n "${FLATPAK_DIR}" ]]
 then
     pushd "${FLATPAK_DIR}" > /dev/null
-    for file in $(find repo)
+	while IFS= read -r -d '' file
     do
         if [[ "${file}" == "repo/.lock" ]]
         then
@@ -33,7 +33,7 @@ then
         fi
         echo "-map ${PWD}/${file} flatpak/${file}"
         echo "-chmod 0444 flatpak/${file}"
-    done
+    done < <(find repo -print0)
     popd > /dev/null
 fi
 
@@ -44,10 +44,10 @@ then
 fi
 
 pushd "${PWD}/../container" > /dev/null
-for file in $(find "${IMAGE_NAME}" -type f)
+while IFS= read -r -d '' file
 do
     echo "-map ${PWD}/${file} ${file}"
     echo "-chmod 0444 ${file}"
-done
+done < <(find "${IMAGE_NAME}" -type f -print0)
 popd > /dev/null
 echo "-end"

--- a/xorriso/gen_input.sh
+++ b/xorriso/gen_input.sh
@@ -44,7 +44,7 @@ then
 fi
 
 pushd "${PWD}/../container" > /dev/null
-for file in $(find "${IMAGE_NAME}-${IMAGE_TAG}" -type f)
+for file in $(find "${IMAGE_NAME}" -type f)
 do
     echo "-map ${PWD}/${file} ${file}"
     echo "-chmod 0444 ${file}"


### PR DESCRIPTION
Ublue has over 128 layers, which prevents the image from being pulled with docker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added generation of a root filesystem tarball from the built container image to streamline Flatpak repository creation.
* **Bug Fixes**
  * Improved the Flatpak build flow to import the prebuilt container tarball before running repository creation.
  * Updated installer/ISO input generation to match the new image naming, and fixed handling of filenames with special characters.
* **Chores**
  * Standardized container build outputs and aligned dependency installation/order in the build workflow.
  * Tightened shell behavior during build execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->